### PR TITLE
fix: some mailboxes not supporting REST API

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,2 +1,8 @@
 // Configuration token for Microsoft Outlook OAuth
 export const MICROSOFT_CONFIG = 'MICROSOFT_CONFIG';
+
+// Microsoft Graph API error codes
+export const GRAPH_ERROR_CODES = {
+  // this is happening when the mailbox is not enabled for REST API, soft-deleted, on-premise, inactive, etc.
+  MAILBOX_NOT_ENABLED: 'MailboxNotEnabledForRESTAPI',
+} as const;

--- a/src/controllers/microsoft-auth.controller.ts
+++ b/src/controllers/microsoft-auth.controller.ts
@@ -2,6 +2,7 @@ import { Controller, Get, Query, Logger, Res, HttpStatus } from '@nestjs/common'
 import { Response } from 'express';
 import { ApiTags, ApiResponse, ApiQuery, ApiOperation, ApiProduces } from '@nestjs/swagger';
 import { MicrosoftAuthService } from '../services/auth/microsoft-auth.service';
+import { MailboxInactiveError } from '../errors/mailbox-inactive.error';
 
 @ApiTags('Microsoft Auth')
 @Controller('auth/microsoft')
@@ -96,6 +97,27 @@ export class MicrosoftAuthController {
       `);
     } catch (error) {
       this.logger.error('Error handling OAuth callback:', error);
+
+      if (error instanceof MailboxInactiveError) {
+        return res.status(HttpStatus.OK).send(`
+          <h1>Calendar Connection Failed</h1>
+          <p>Your Microsoft account was authenticated, but we couldn't access your mailbox.</p>
+          <p>This usually means your mailbox is either:</p>
+          <ul>
+            <li>Hosted on an on-premise Exchange server (not Exchange Online)</li>
+            <li>Inactive or has been soft-deleted</li>
+            <li>Missing an Exchange Online license</li>
+          </ul>
+          <p>Please contact your IT administrator to ensure your mailbox is hosted in Exchange Online (Microsoft 365).</p>
+          <p>You can close this tab now.</p>
+          <script>
+            if (window.opener) {
+              window.opener.postMessage({ type: 'microsoft-auth-failed', error: 'Your mailbox is not supported. It may be inactive, soft-deleted, or hosted on-premise. Please contact your IT administrator.' }, '*');
+            }
+          </script>
+        `);
+      }
+
       return res
         .status(HttpStatus.INTERNAL_SERVER_ERROR)
         .send('An error occurred during authentication');

--- a/src/errors/mailbox-inactive.error.ts
+++ b/src/errors/mailbox-inactive.error.ts
@@ -1,0 +1,6 @@
+export class MailboxInactiveError extends Error {
+  constructor(public readonly graphMessage: string) {
+    super(`Mailbox is not accessible: ${graphMessage}`);
+    this.name = 'MailboxInactiveError';
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,6 +25,9 @@ export * from './enums/show-as-type.enum';
 // Export constants
 export * from './constants';
 
+// Export errors
+export * from './errors/mailbox-inactive.error';
+
 // Export controllers
 export * from './controllers/calendar.controller';
 export * from './controllers/microsoft-auth.controller';

--- a/src/services/auth/microsoft-auth.service.ts
+++ b/src/services/auth/microsoft-auth.service.ts
@@ -4,7 +4,7 @@ import axios from 'axios';
 import { TokenResponse } from '../../interfaces/outlook/token-response.interface';
 import { CalendarService } from '../calendar/calendar.service';
 import { EmailService } from '../email/email.service';
-import { MICROSOFT_CONFIG } from '../../constants';
+import { GRAPH_ERROR_CODES, MICROSOFT_CONFIG } from '../../constants';
 import { MicrosoftOutlookConfig } from '../../interfaces/config/outlook-config.interface';
 import { OutlookEventTypes } from '../../enums/event-types.enum';
 import * as crypto from 'crypto';
@@ -18,6 +18,7 @@ import { FindOptionsWhere, Repository } from 'typeorm';
 import { MicrosoftUser } from '../../entities/microsoft-user.entity';
 import { retryWithBackoff } from '../../utils/retry.util';
 import { TtlCache } from '../../utils/ttl-cache.util';
+import { MailboxInactiveError } from '../../errors/mailbox-inactive.error';
 
 /**
  * Important terminology:
@@ -535,6 +536,10 @@ export class MicrosoftAuthService {
         scopeString // Store the exact Microsoft scopes used
       );
 
+      // Validate mailbox is accessible before proceeding with calendar setup
+      this.logger.log(`[${correlationId}] Validating mailbox access`);
+      await this.validateMailboxAccess(tokenData.access_token, correlationId);
+
       // Emit event that the user has been authenticated
       this.logger.log(`[${correlationId}] Emitting USER_AUTHENTICATED event`);
       await Promise.resolve(
@@ -551,6 +556,11 @@ export class MicrosoftAuthService {
       this.logger.log(`[${correlationId}] Token exchange completed successfully`);
       return tokenData;
     } catch (error) {
+      if (error instanceof MailboxInactiveError) {
+        // Deactivate the saved Microsoft user since their mailbox isn't usable
+        await this.deactivateMicrosoftUser(stateData.userId, correlationId);
+        throw error; // Let controller handle with user-friendly message
+      }
       if (axios.isAxiosError(error)) {
         this.logger.error(
           `[${correlationId}] Microsoft token exchange failed:`,
@@ -568,7 +578,59 @@ export class MicrosoftAuthService {
       throw new Error('Failed to exchange code for token');
     }
   }
-  
+
+  /**
+   * Validates that the user's mailbox is accessible via Microsoft Graph.
+   * Catches inactive, soft-deleted, or on-premise mailboxes early — before
+   * calendar import is attempted.
+   */
+  private isMailboxDisabledError(code?: string, message?: string): boolean {
+    return (
+      code === GRAPH_ERROR_CODES.MAILBOX_NOT_ENABLED ||
+      /inactive|soft-deleted|on-premise/i.test(message ?? '')
+    );
+  }
+
+  private async validateMailboxAccess(accessToken: string, correlationId: string): Promise<void> {
+    try {
+      await axios.get('https://graph.microsoft.com/v1.0/me/mailboxSettings', {
+        headers: { Authorization: `Bearer ${accessToken}` },
+      });
+    } catch (error) {
+      if (axios.isAxiosError(error)) {
+        const responseData = error.response?.data as { error?: { code?: string; message?: string } } | undefined;
+        const graphError = responseData?.error;
+        const code: string | undefined = graphError?.code;
+        const message: string = graphError?.message || error.message;
+        if (this.isMailboxDisabledError(code, message)) {
+          this.logger.warn(`[${correlationId}] Mailbox validation failed: ${code} — ${message}`);
+          throw new MailboxInactiveError(message);
+        }
+      }
+      // Non-mailbox errors (network, transient) — don't block auth
+      this.logger.warn(
+        `[${correlationId}] Mailbox validation call failed (non-blocking): ${error instanceof Error ? error.message : String(error)}`
+      );
+    }
+  }
+
+  /**
+   * Deactivates a Microsoft user record when their mailbox turns out to be unusable.
+   */
+  private async deactivateMicrosoftUser(externalUserId: string, correlationId: string): Promise<void> {
+    try {
+      await this.microsoftUserRepository.update(
+        { externalUserId } as FindOptionsWhere<MicrosoftUser>,
+        { isActive: false },
+      );
+      this.logger.log(`[${correlationId}] Deactivated Microsoft user ${externalUserId} due to unusable mailbox`);
+    } catch (err) {
+      this.logger.warn(
+        `[${correlationId}] Failed to deactivate Microsoft user ${externalUserId}: ${err instanceof Error ? err.message : String(err)}`
+      );
+    }
+  }
+
   /**
    * Setup webhook subscriptions for a user based on requested scopes
    * @param externalUserId - External user ID from the host application


### PR DESCRIPTION
# Problem:

nestjs-outlook only integrate with user mailboxes that supports REST API.
some mailboxes is on-premise, soft-deleted, or inactive.

# Changes:

surface up the error that indicate that the user account is not supporting the REST API