### PR TITLE
fix: invalid refresh token

### DIFF
--- a/src/controllers/subscription-admin.controller.ts
+++ b/src/controllers/subscription-admin.controller.ts
@@ -1,0 +1,73 @@
+import { Controller, Post, Delete, HttpCode, Logger, Param, NotFoundException } from '@nestjs/common';
+import { ApiTags, ApiResponse, ApiOperation, ApiParam } from '@nestjs/swagger';
+import { MicrosoftSubscriptionService } from '../services/subscription/microsoft-subscription.service';
+
+/**
+ * Admin endpoints for on-demand subscription lifecycle operations.
+ *
+ * These endpoints invoke methods otherwise driven by cron / Graph lifecycle events:
+ *   - POST   /subscriptions/admin/renew/:subscriptionId → renewWebhookSubscription
+ *   - POST   /subscriptions/admin/health                → verifySubscriptionHealth (same as 6-hourly cron)
+ *   - DELETE /subscriptions/admin/:subscriptionId/:userId → deleteWebhookSubscription
+ */
+@ApiTags('SubscriptionAdmin')
+@Controller('subscriptions/admin')
+export class SubscriptionAdminController {
+  private readonly logger = new Logger(SubscriptionAdminController.name);
+
+  constructor(
+    private readonly subscriptionService: MicrosoftSubscriptionService,
+  ) {}
+
+  @Post('renew/:subscriptionId')
+  @HttpCode(200)
+  @ApiOperation({ summary: 'Renew a single subscription by ID.' })
+  @ApiParam({ name: 'subscriptionId', description: 'The Microsoft Graph subscription ID to renew.' })
+  @ApiResponse({ status: 200, description: 'Subscription renewed. Returns the new expiration timestamp.' })
+  @ApiResponse({ status: 404, description: 'Subscription not found in local database.' })
+  async triggerRenewOne(
+    @Param('subscriptionId') subscriptionId: string,
+  ): Promise<{ subscriptionId: string; newExpiration: string | null }> {
+    this.logger.log(`[admin] Manual renewWebhookSubscription trigger for ${subscriptionId}`);
+    const subscription = await this.subscriptionService.getSubscription(subscriptionId);
+    if (!subscription) {
+      throw new NotFoundException(`Subscription ${subscriptionId} not found in local database`);
+    }
+    const renewed = await this.subscriptionService.renewWebhookSubscription(
+      subscriptionId,
+      subscription.userId,
+    );
+    return {
+      subscriptionId,
+      newExpiration: renewed.expirationDateTime ?? null,
+    };
+  }
+
+  @Post('health')
+  @HttpCode(200)
+  @ApiOperation({ summary: 'Run the subscription health-check job on demand (same as the 6-hourly cron).' })
+  @ApiResponse({ status: 200, description: 'Health-check job completed. See logs for per-subscription outcomes.' })
+  async triggerHealthCheck(): Promise<{ triggered: boolean; at: string }> {
+    const at = new Date().toISOString();
+    this.logger.log(`[admin] Manual verifySubscriptionHealth trigger at ${at}`);
+    await this.subscriptionService.verifySubscriptionHealth();
+    return { triggered: true, at };
+  }
+
+  @Delete(':subscriptionId/:userId')
+  @HttpCode(200)
+  @ApiOperation({ summary: 'Delete a subscription at Microsoft and deactivate it locally.' })
+  @ApiParam({ name: 'subscriptionId', description: 'The Microsoft Graph subscription ID to delete.' })
+  @ApiParam({ name: 'userId', description: 'External user ID (string) or internal user ID (numeric) owning the subscription.' })
+  @ApiResponse({ status: 200, description: 'Subscription deleted (or already gone at Microsoft).' })
+  async triggerDelete(
+    @Param('subscriptionId') subscriptionId: string,
+    @Param('userId') userId: string,
+  ): Promise<{ subscriptionId: string; deleted: boolean }> {
+    this.logger.log(`[admin] Manual deleteWebhookSubscription trigger for ${subscriptionId} (user ${userId})`);
+    const numericUserId = Number(userId);
+    const resolvedUserId = Number.isFinite(numericUserId) && String(numericUserId) === userId ? numericUserId : userId;
+    const deleted = await this.subscriptionService.deleteWebhookSubscription(subscriptionId, resolvedUserId);
+    return { subscriptionId, deleted };
+  }
+}

--- a/src/entities/microsoft-user.entity.ts
+++ b/src/entities/microsoft-user.entity.ts
@@ -6,6 +6,7 @@ import {
   UpdateDateColumn,
   Index,
 } from 'typeorm';
+import { MicrosoftUserStatus } from '../enums/microsoft-user-status.enum';
 
 /**
  * Entity for storing Microsoft user information including OAuth tokens
@@ -35,6 +36,14 @@ export class MicrosoftUser {
 
   @Column({ name: 'is_active', default: true })
   isActive: boolean = true;
+
+  @Column({
+    name: 'status',
+    type: 'varchar',
+    length: 32,
+    default: MicrosoftUserStatus.ACTIVE,
+  })
+  status: MicrosoftUserStatus = MicrosoftUserStatus.ACTIVE;
 
   @Column({ name: 'default_calendar_id', type: 'varchar', length: 255, nullable: true })
   defaultCalendarId: string | null = null;

--- a/src/enums/microsoft-user-status.enum.ts
+++ b/src/enums/microsoft-user-status.enum.ts
@@ -1,0 +1,4 @@
+export enum MicrosoftUserStatus {
+  ACTIVE = 'ACTIVE',
+  CORRUPTED = 'CORRUPTED',
+}

--- a/src/errors/microsoft-refresh-token-invalid.error.ts
+++ b/src/errors/microsoft-refresh-token-invalid.error.ts
@@ -1,0 +1,6 @@
+export class MicrosoftRefreshTokenInvalidError extends Error {
+  constructor(public readonly internalUserId: number) {
+    super(`Microsoft refresh token is invalid or expired for user ${internalUserId}`);
+    this.name = 'MicrosoftRefreshTokenInvalidError';
+  }
+}

--- a/src/microsoft-outlook.module.ts
+++ b/src/microsoft-outlook.module.ts
@@ -6,6 +6,7 @@ import { MicrosoftAuthService } from "./services/auth/microsoft-auth.service";
 import { MicrosoftAuthController } from "./controllers/microsoft-auth.controller";
 import { CalendarController } from "./controllers/calendar.controller";
 import { EmailController } from "./controllers/email.controller";
+import { SubscriptionAdminController } from "./controllers/subscription-admin.controller";
 import { OutlookWebhookSubscription } from "./entities/outlook-webhook-subscription.entity";
 import { OutlookWebhookSubscriptionRepository } from "./repositories/outlook-webhook-subscription.repository";
 import { MICROSOFT_CONFIG } from "./constants";
@@ -44,7 +45,7 @@ export const { ConfigurableModuleClass, MODULE_OPTIONS_TOKEN } =
     ]),
     EventEmitterModule.forRoot(),
   ],
-  controllers: [MicrosoftAuthController, CalendarController, EmailController],
+  controllers: [MicrosoftAuthController, CalendarController, EmailController, SubscriptionAdminController],
   providers: [
     {
       provide: MICROSOFT_CONFIG,

--- a/src/migrations/1776700000000-AddMicrosoftUserStatusColumn.ts
+++ b/src/migrations/1776700000000-AddMicrosoftUserStatusColumn.ts
@@ -1,0 +1,20 @@
+import { MigrationInterface, QueryRunner, TableColumn } from 'typeorm';
+
+export class AddMicrosoftUserStatusColumn1776700000000 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.addColumn(
+      'microsoft_users',
+      new TableColumn({
+        name: 'status',
+        type: 'varchar',
+        length: '32',
+        isNullable: false,
+        default: "'ACTIVE'",
+      })
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.dropColumn('microsoft_users', 'status');
+  }
+}

--- a/src/repositories/outlook-webhook-subscription.repository.ts
+++ b/src/repositories/outlook-webhook-subscription.repository.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository, LessThan, MoreThan } from 'typeorm';
+import { Repository, MoreThan } from 'typeorm';
 import { OutlookWebhookSubscription } from '../entities/outlook-webhook-subscription.entity';
 import { TtlCache } from '../utils/ttl-cache.util';
 
@@ -78,32 +78,6 @@ export class OutlookWebhookSubscriptionRepository {
     await this.repository.update({ subscriptionId }, { isActive: false, updatedAt: new Date() });
     this.bySubscriptionId.delete(subscriptionId);
     this.byUserId.clear();
-  }
-
-  async findSubscriptionsNeedingRenewal(
-    hoursUntilExpiration: number,
-    options?: { skipLocked?: boolean },
-  ): Promise<OutlookWebhookSubscription[]> {
-    const expirationThreshold = new Date();
-    expirationThreshold.setHours(expirationThreshold.getHours() + hoursUntilExpiration);
-
-    // When skipLocked is true, use FOR UPDATE SKIP LOCKED to prevent
-    // multiple instances from renewing the same subscription concurrently
-    if (options?.skipLocked) {
-      return this.repository
-        .createQueryBuilder('sub')
-        .setLock('pessimistic_write_or_fail')
-        .where('sub.isActive = :active', { active: true })
-        .andWhere('sub.expirationDateTime < :threshold', { threshold: expirationThreshold })
-        .getMany();
-    }
-
-    return this.repository.find({
-      where: {
-        isActive: true,
-        expirationDateTime: LessThan(expirationThreshold),
-      },
-    });
   }
 
   async findActiveSubscriptions(): Promise<OutlookWebhookSubscription[]> {

--- a/src/services/auth/microsoft-auth.service.ts
+++ b/src/services/auth/microsoft-auth.service.ts
@@ -23,6 +23,19 @@ import { MicrosoftRefreshTokenInvalidError } from '../../errors/microsoft-refres
 import { MicrosoftUserStatus } from '../../enums/microsoft-user-status.enum';
 
 /**
+ * OAuth2 `error` values from Microsoft's token endpoint that explicitly mean
+ * "the user must re-authenticate." Transient errors (network, 5xx, rate limits)
+ * and caller-side bugs (invalid_client, invalid_request) are intentionally excluded —
+ * marking a user CORRUPTED for those would force an unnecessary re-auth.
+ */
+const CORRUPTED_TRIGGER_ERROR_CODES: ReadonlySet<string> = new Set([
+  'invalid_grant',          // refresh token expired / revoked / consent withdrawn
+  'interaction_required',   // conditional access / MFA challenge
+  'consent_required',       // admin consent lapsed or new permissions needed
+  'login_required',         // session forgotten
+]);
+
+/**
  * Important terminology:
  *
  * - externalUserId (string): The ID of the user in the host application that uses this library.
@@ -426,6 +439,9 @@ export class MicrosoftAuthService {
 
     // Error handling
     catch (error) {
+      // Preserve typed error so callers can discriminate "user needs re-auth"
+      // from generic token failures.
+      if (error instanceof MicrosoftRefreshTokenInvalidError) throw error;
       const identifier = params.internalUserId
         ? `internal user ID ${String(params.internalUserId)}`
         : `external user ID ${params.externalUserId}`;
@@ -826,20 +842,12 @@ export class MicrosoftAuthService {
             `Microsoft API error refreshing token for user ID ${String(internalUserId)}: Status: ${String(error.response.status)}, Response: ${JSON.stringify(error.response.data)}`
           );
 
-          // Check for specific error conditions from Microsoft
-          const errorData = error.response.data as { error?: string };
-          if (errorData.error === 'invalid_grant') {
-            // Persist CORRUPTED so the host app can prompt the user to re-authenticate.
-            // A fresh successful saveMicrosoftUser will flip this back to ACTIVE.
-            try {
-              internalUser.status = MicrosoftUserStatus.CORRUPTED;
-              await this.microsoftUserRepository.save(internalUser);
-              this.invalidateUserCache(internalUser);
-            } catch (dbErr) {
-              this.logger.error(
-                `Failed to mark user ${String(internalUserId)} as CORRUPTED: ${dbErr instanceof Error ? dbErr.message : 'unknown'}`,
-              );
-            }
+          // Any OAuth2 `error` code that means "user must re-authenticate" flips
+          // the user to CORRUPTED. Transient errors (no error field, server_error)
+          // fall through unchanged so Microsoft outages don't mass-mark users.
+          const errorCode = (error.response.data as { error?: string }).error;
+          if (errorCode && CORRUPTED_TRIGGER_ERROR_CODES.has(errorCode)) {
+            await this.markUserAsCorrupted(internalUser, errorCode);
             throw new MicrosoftRefreshTokenInvalidError(internalUserId);
           }
         }
@@ -849,6 +857,27 @@ export class MicrosoftAuthService {
       if (error instanceof MicrosoftRefreshTokenInvalidError) throw error;
       this.logger.error(`Error refreshing access token for user ID ${String(internalUserId)}:`, error);
       throw new Error('Failed to refresh access token from Microsoft');
+    }
+  }
+
+  /**
+   * Flip a user to CORRUPTED so the host app can prompt re-authentication.
+   * A subsequent successful saveMicrosoftUser flips it back to ACTIVE.
+   * Fail-open: DB errors are logged, never thrown.
+   */
+  private async markUserAsCorrupted(
+    user: MicrosoftUser,
+    reason: string,
+  ): Promise<void> {
+    try {
+      user.status = MicrosoftUserStatus.CORRUPTED;
+      await this.microsoftUserRepository.save(user);
+      this.invalidateUserCache(user);
+      this.logger.warn(`User ${String(user.id)} marked CORRUPTED (reason: ${reason})`);
+    } catch (dbErr) {
+      this.logger.error(
+        `Failed to mark user ${String(user.id)} as CORRUPTED: ${dbErr instanceof Error ? dbErr.message : 'unknown'}`,
+      );
     }
   }
 

--- a/src/services/auth/microsoft-auth.service.ts
+++ b/src/services/auth/microsoft-auth.service.ts
@@ -19,6 +19,8 @@ import { MicrosoftUser } from '../../entities/microsoft-user.entity';
 import { retryWithBackoff } from '../../utils/retry.util';
 import { TtlCache } from '../../utils/ttl-cache.util';
 import { MailboxInactiveError } from '../../errors/mailbox-inactive.error';
+import { MicrosoftRefreshTokenInvalidError } from '../../errors/microsoft-refresh-token-invalid.error';
+import { MicrosoftUserStatus } from '../../enums/microsoft-user-status.enum';
 
 /**
  * Important terminology:
@@ -318,6 +320,7 @@ export class MicrosoftAuthService {
     user.tokenExpiry = new Date(Date.now() + expiresIn * 1000);
     user.scopes = scopes;
     user.isActive = true; // Reactivate if previously inactive
+    user.status = MicrosoftUserStatus.ACTIVE; // Clear CORRUPTED on successful re-auth
 
     await this.microsoftUserRepository.save(user);
     this.invalidateUserCache(user);
@@ -826,12 +829,24 @@ export class MicrosoftAuthService {
           // Check for specific error conditions from Microsoft
           const errorData = error.response.data as { error?: string };
           if (errorData.error === 'invalid_grant') {
-            throw new Error('Microsoft refresh token is invalid or expired');
+            // Persist CORRUPTED so the host app can prompt the user to re-authenticate.
+            // A fresh successful saveMicrosoftUser will flip this back to ACTIVE.
+            try {
+              internalUser.status = MicrosoftUserStatus.CORRUPTED;
+              await this.microsoftUserRepository.save(internalUser);
+              this.invalidateUserCache(internalUser);
+            } catch (dbErr) {
+              this.logger.error(
+                `Failed to mark user ${String(internalUserId)} as CORRUPTED: ${dbErr instanceof Error ? dbErr.message : 'unknown'}`,
+              );
+            }
+            throw new MicrosoftRefreshTokenInvalidError(internalUserId);
           }
         }
         throw error; // Re-throw for the outer catch to handle
       }
     } catch (error) {
+      if (error instanceof MicrosoftRefreshTokenInvalidError) throw error;
       this.logger.error(`Error refreshing access token for user ID ${String(internalUserId)}:`, error);
       throw new Error('Failed to refresh access token from Microsoft');
     }

--- a/src/services/calendar/calendar.service.ts
+++ b/src/services/calendar/calendar.service.ts
@@ -1498,6 +1498,9 @@ export class CalendarService {
         `[WEBHOOK_IDENTIFIED] webhookTraceId=${webhookTraceId || 'none'}, userId=${subscription.userId}, subscriptionId=${subscription.subscriptionId}`
       );
 
+      // Track notification arrival so verifySubscriptionHealth can detect stale subscriptions.
+      this.subscriptionService.trackNotificationReceived(subscription.subscriptionId);
+
       this.eventEmitter.emit(OutlookEventTypes.EVENT_NOTIFICATION, {
         userId: subscription.userId,
         subscriptionId: subscription.subscriptionId,

--- a/src/services/subscription/microsoft-subscription.service.ts
+++ b/src/services/subscription/microsoft-subscription.service.ts
@@ -1,11 +1,11 @@
 import { randomUUID } from "crypto";
 import { Injectable, Logger, Inject, forwardRef } from '@nestjs/common';
 import { EventEmitter2 } from '@nestjs/event-emitter';
-import { Cron, CronExpression } from '@nestjs/schedule';
+import { Cron } from '@nestjs/schedule';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository, Not } from 'typeorm';
+import { Repository, Not, In } from 'typeorm';
 import axios from 'axios';
-import { Subscription } from '../../types';
+import { Subscription, BatchRequestPayload, BatchResponsePayload, BatchResponse } from '../../types';
 import { MicrosoftAuthService } from '../auth/microsoft-auth.service';
 import { OutlookWebhookSubscriptionRepository } from '../../repositories/outlook-webhook-subscription.repository';
 import { OutlookWebhookSubscription } from '../../entities/outlook-webhook-subscription.entity';
@@ -13,7 +13,9 @@ import { MicrosoftUser } from '../../entities/microsoft-user.entity';
 import { MICROSOFT_CONFIG } from '../../constants';
 import { MicrosoftOutlookConfig } from '../../interfaces/config/outlook-config.interface';
 import { OutlookEventTypes } from '../../enums/event-types.enum';
+import { MicrosoftUserStatus } from '../../enums/microsoft-user-status.enum';
 import { UserIdConverterService } from '../shared/user-id-converter.service';
+import { GraphRateLimiterService } from '../shared/graph-rate-limiter.service';
 import { executeGraphApiCall } from '../../utils/outlook-api-executor.util';
 
 /**
@@ -53,6 +55,28 @@ export interface SubscriptionCleanupResult {
   errors: Array<{ subscriptionId: string; error: string }>;
 }
 
+// ─── Health-check tuning constants ──────────────────────────────────
+/** Microsoft Graph batch API allows at most 20 inner requests per /$batch call. */
+const GRAPH_BATCH_SIZE = 20;
+/** Only subs expiring within this window get a Graph /subscriptions/{id} verification call. */
+const HEALTH_CHECK_WINDOW_HOURS = 24;
+/** A sub expiring within this window is force-renewed during the health check. */
+const FORCE_RENEWAL_WINDOW_HOURS = 12;
+/** A sub with no notifications in this window is treated as stale. */
+const STALE_NOTIFICATION_THRESHOLD_HOURS = 24;
+
+/**
+ * Per-pass counters for the health check. Helpers return a freshly-allocated
+ * instance and the orchestrator sums them — no shared mutable state.
+ */
+interface HealthCheckCounters {
+  verified: number;
+  recreated: number;
+  renewed: number;
+  staleDetected: number;
+  failed: number;
+}
+
 /**
  * Centralized service for managing Microsoft Graph API subscriptions
  * Handles creation, renewal, deletion, health checks, and cleanup of
@@ -74,6 +98,7 @@ export class MicrosoftSubscriptionService {
     @InjectRepository(MicrosoftUser)
     private readonly microsoftUserRepository: Repository<MicrosoftUser>,
     private readonly userIdConverter: UserIdConverterService,
+    private readonly rateLimiter: GraphRateLimiterService,
   ) {}
 
   // ─── Microsoft Graph API subscription queries ───────────────────────
@@ -409,46 +434,16 @@ export class MicrosoftSubscriptionService {
 
         // Subscription no longer exists at Microsoft — deactivate and attempt re-creation
         if (statusCode === 404) {
-          this.logger.warn(
-            `[${correlationId}] Subscription ${subscriptionId} not found at Microsoft. ` +
-            `Deactivating and attempting re-creation.`
+          const outcome = await this.handleSubscriptionNotFoundAtMicrosoft(
+            subscriptionId,
+            internalUserId,
+            'renewal_404',
+            correlationId,
           );
-
-          await this.webhookSubscriptionRepository.deactivateSubscription(
-            subscriptionId
-          );
-
-          // Attempt to re-create the subscription
-          try {
-            const externalUserId = await this.userIdConverter.internalToExternal(internalUserId);
-            await this.createWebhookSubscription(externalUserId);
-
-            this.logger.log(
-              `[${correlationId}] Successfully re-created subscription for user ${internalUserId} after 404`
-            );
-
-            this.eventEmitter.emit(OutlookEventTypes.SUBSCRIPTION_RECREATED, {
-              subscriptionId,
-              userId: internalUserId,
-              reason: 'renewal_404',
-            });
-
-            // Return early — the old subscription is replaced
+          if (outcome === 'recreated') {
+            // The old subscription has been replaced by a fresh one.
             return {} as Subscription;
-          } catch (recreateError) {
-            const recreateMsg = recreateError instanceof Error ? recreateError.message : 'Unknown error';
-            this.logger.error(
-              `[${correlationId}] Failed to re-create subscription for user ${internalUserId}: ${recreateMsg}`
-            );
-
-            this.eventEmitter.emit(OutlookEventTypes.SUBSCRIPTION_RECREATION_FAILED, {
-              subscriptionId,
-              userId: internalUserId,
-              reason: 'renewal_404',
-              error: recreateMsg,
-            });
           }
-
           throw new Error(
             `Subscription ${subscriptionId} not found at Microsoft. ` +
             `Subscription has been deactivated and re-creation failed.`
@@ -622,6 +617,19 @@ export class MicrosoftSubscriptionService {
     try {
       // Convert external to internal ID
       const internalUserId = await this.userIdConverter.externalToInternal(externalUserId, {cache: false});
+
+      // A CORRUPTED user needs to re-authenticate — report as not connected so
+      // the UI prompts a fresh OAuth flow instead of offering "Disconnect".
+      const user = await this.microsoftUserRepository.findOne({
+        select: ['id', 'status'],
+        where: { id: internalUserId },
+      });
+      if (!user || user.status === MicrosoftUserStatus.CORRUPTED) {
+        this.logger.debug(
+          `[getActiveSubscriptionForUser] User ${externalUserId} is missing or CORRUPTED — reporting as not connected`
+        );
+        return null;
+      }
 
       this.logger.log(`[getActiveSubscriptionForUser] Getting active subscription for user ${externalUserId} (internalUserId: ${internalUserId})`);
       const subscription = await this.webhookSubscriptionRepository.findActiveByUserId(internalUserId);
@@ -812,199 +820,356 @@ export class MicrosoftSubscriptionService {
   // ─── Scheduled jobs ─────────────────────────────────────────────────
 
   /**
-   * Scheduled job that checks for webhook subscriptions that will expire soon
-   * and renews them
-   */
-  @Cron(CronExpression.EVERY_HOUR)
-  async renewSubscriptions(): Promise<void> {
-    try {
-      // Use skipLocked to prevent multiple instances from renewing the same
-      // subscription concurrently (safe across ECS tasks)
-      const expiringSubscriptions =
-        await this.webhookSubscriptionRepository.findSubscriptionsNeedingRenewal(
-          24, // hours until expiration
-          { skipLocked: true }
-        );
-
-      if (expiringSubscriptions.length === 0) {
-        this.logger.debug("No subscriptions need renewal");
-        return;
-      }
-
-      this.logger.log(
-        `Found ${String(expiringSubscriptions.length)} subscriptions that need renewal`
-      );
-
-      // Renew each subscription
-      for (const subscription of expiringSubscriptions) {
-        try {
-          // Renew the subscription using the internal userId to get a fresh token
-          await this.renewWebhookSubscription(
-            subscription.subscriptionId,
-            subscription.userId
-          );
-        } catch (error) {
-          this.logger.error(
-            `Failed to renew subscription ${subscription.subscriptionId}:`,
-            error
-          );
-          // Continue with the next subscription even if this one failed
-        }
-      }
-    } catch (error) {
-      this.logger.error("Error in subscription renewal job:", error);
-    }
-  }
-
-  /**
    * Scheduled job that verifies active subscriptions still exist at Microsoft
    * and detects stale subscriptions that stopped receiving notifications.
    *
-   * Runs every 6 hours. For each active subscription:
-   * - Verifies it exists at Microsoft (GET /subscriptions/{id})
-   * - If 404: the subscription is dead — attempts re-creation
-   * - If expiring within 12h: forces immediate renewal
-   * - If no notification received in 24h: emits LIFECYCLE_MISSED event for delta sync recovery
+   * Runs every 6 hours. Work is split into two passes:
+   * 1. Stale-notification pass (in-memory, no Graph calls) — emits LIFECYCLE_MISSED
+   *    for any sub whose lastNotificationAt is older than 24 h.
+   * 2. Graph-verify pass (only subs expiring within 24 h) — grouped by user, batched
+   *    via /$batch (20 per call), rate-limited per user. Handles 404 re-creation and
+   *    "<12 h to expiry" forced renewal.
    */
   @Cron('0 */6 * * *')
   async verifySubscriptionHealth(): Promise<void> {
     const correlationId = `health-check-${Date.now()}`;
 
     try {
-      const activeSubscriptions =
-        await this.webhookSubscriptionRepository.findActiveSubscriptions();
+      const allActiveSubs = await this.webhookSubscriptionRepository.findActiveSubscriptions();
 
-      if (activeSubscriptions.length === 0) {
+      if (allActiveSubs.length === 0) {
         this.logger.debug(`[${correlationId}] No active subscriptions to verify`);
         return;
       }
 
+      // Skip subs whose owning user is CORRUPTED — any outbound Graph work for
+      // them would just trigger the same invalid_grant and we've already signalled
+      // the host app to prompt re-auth.
+      const corruptedUserIds = await this.findCorruptedUserIds(allActiveSubs);
+      const activeSubs = corruptedUserIds.size > 0
+        ? allActiveSubs.filter((sub) => !corruptedUserIds.has(sub.userId))
+        : allActiveSubs;
+
+      const skipped = allActiveSubs.length - activeSubs.length;
+      if (skipped > 0) {
+        this.logger.log(
+          `[${correlationId}] Skipping ${skipped} sub(s) owned by ${corruptedUserIds.size} CORRUPTED user(s)`
+        );
+      }
+
+      const expiringSoon = this.filterExpiringSoon(activeSubs, HEALTH_CHECK_WINDOW_HOURS);
+
       this.logger.log(
-        `[${correlationId}] Verifying health of ${String(activeSubscriptions.length)} active subscriptions`
+        `[${correlationId}] Health check: ${activeSubs.length} active, ${expiringSoon.length} expiring within ${HEALTH_CHECK_WINDOW_HOURS}h`
       );
 
-      let verified = 0;
-      let recreated = 0;
-      let staleDetected = 0;
-      let failed = 0;
+      const counters: HealthCheckCounters = { verified: 0, recreated: 0, renewed: 0, staleDetected: 0, failed: 0 };
 
-      for (const subscription of activeSubscriptions) {
-        try {
-          const accessToken = await this.microsoftAuthService.getUserAccessToken({
-            internalUserId: subscription.userId,
-          });
+      counters.staleDetected = this.detectStaleSubscriptions(activeSubs, correlationId);
 
-          // Verify subscription exists at Microsoft
-          const response = await executeGraphApiCall(
-            () => axios.get<Subscription>(
-              `${this.graphApiBaseUrl}/subscriptions/${subscription.subscriptionId}`,
-              {
-                headers: {
-                  Authorization: `Bearer ${accessToken}`,
-                  "Prefer": 'IdType="ImmutableId"',
-                },
-              }
-            ),
-            {
-              logger: this.logger,
-              resourceName: `verify subscription ${subscription.subscriptionId}`,
-              maxRetries: 2,
-              return404AsNull: true,
-            }
-          );
-
-          if (!response) {
-            // Subscription doesn't exist at Microsoft — attempt re-creation
-            this.logger.warn(
-              `[${correlationId}] Subscription ${subscription.subscriptionId} not found at Microsoft. Attempting re-creation.`
-            );
-
-            await this.webhookSubscriptionRepository.deactivateSubscription(
-              subscription.subscriptionId
-            );
-
-            try {
-              const externalUserId = await this.userIdConverter.internalToExternal(subscription.userId);
-              await this.createWebhookSubscription(externalUserId);
-              recreated++;
-
-              this.eventEmitter.emit(OutlookEventTypes.SUBSCRIPTION_RECREATED, {
-                subscriptionId: subscription.subscriptionId,
-                userId: subscription.userId,
-                reason: 'health_check_404',
-              });
-            } catch (recreateError) {
-              failed++;
-              this.logger.error(
-                `[${correlationId}] Failed to re-create subscription for user ${String(subscription.userId)}: ${
-                  recreateError instanceof Error ? recreateError.message : 'Unknown error'
-                }`
-              );
-
-              this.eventEmitter.emit(OutlookEventTypes.SUBSCRIPTION_RECREATION_FAILED, {
-                subscriptionId: subscription.subscriptionId,
-                userId: subscription.userId,
-                reason: 'health_check_404',
-                error: recreateError instanceof Error ? recreateError.message : 'Unknown error',
-              });
-            }
-
-            continue;
-          }
-
-          verified++;
-
-          // Check if expiring within 12 hours — force immediate renewal
-          if (response.data.expirationDateTime) {
-            const expiration = new Date(response.data.expirationDateTime);
-            const twelveHoursFromNow = new Date();
-            twelveHoursFromNow.setHours(twelveHoursFromNow.getHours() + 12);
-
-            if (expiration < twelveHoursFromNow) {
-              this.logger.log(
-                `[${correlationId}] Subscription ${subscription.subscriptionId} expires within 12h. Forcing renewal.`
-              );
-              await this.renewWebhookSubscription(
-                subscription.subscriptionId,
-                subscription.userId
-              );
-            }
-          }
-
-          // Check for staleness: no notification in 24+ hours
-          if (subscription.lastNotificationAt) {
-            const twentyFourHoursAgo = new Date();
-            twentyFourHoursAgo.setHours(twentyFourHoursAgo.getHours() - 24);
-
-            if (subscription.lastNotificationAt < twentyFourHoursAgo) {
-              this.logger.warn(
-                `[${correlationId}] Subscription ${subscription.subscriptionId} has not received notifications since ${subscription.lastNotificationAt.toISOString()}. Emitting LIFECYCLE_MISSED for delta sync.`
-              );
-
-              staleDetected++;
-
-              // Emit a lifecycle missed event so the calendar layer can trigger delta sync
-              this.eventEmitter.emit(OutlookEventTypes.LIFECYCLE_MISSED, {
-                subscriptionId: subscription.subscriptionId,
-                userId: subscription.userId,
-                reason: 'health_check_stale',
-              });
-            }
-          }
-        } catch (error) {
-          failed++;
-          this.logger.error(
-            `[${correlationId}] Health check failed for subscription ${subscription.subscriptionId}:`,
-            error
-          );
+      if (expiringSoon.length > 0) {
+        const byUser = this.groupByUserId(expiringSoon);
+        for (const [userId, userSubs] of byUser) {
+          const perUser = await this.verifySubscriptionsForUser(userId, userSubs, correlationId);
+          counters.verified += perUser.verified;
+          counters.recreated += perUser.recreated;
+          counters.renewed += perUser.renewed;
+          counters.failed += perUser.failed;
         }
       }
 
       this.logger.log(
-        `[${correlationId}] Health check complete: ${String(verified)} verified, ${String(recreated)} recreated, ${String(staleDetected)} stale-detected, ${String(failed)} failed`
+        `[${correlationId}] Health check complete: ${counters.verified} verified, ${counters.recreated} recreated, ${counters.renewed} renewed, ${counters.staleDetected} stale-detected, ${counters.failed} failed`
       );
     } catch (error) {
       this.logger.error(`[${correlationId}] Subscription health check job failed:`, error);
+    }
+  }
+
+  /**
+   * Return the set of user IDs whose MicrosoftUser.status === CORRUPTED among
+   * the owners of the given subs. One indexed query, no N+1.
+   */
+  private async findCorruptedUserIds(
+    subs: OutlookWebhookSubscription[],
+  ): Promise<Set<number>> {
+    const userIds = Array.from(new Set(subs.map((s) => s.userId)));
+    if (userIds.length === 0) return new Set();
+
+    const rows = await this.microsoftUserRepository.find({
+      select: ['id'],
+      where: { id: In(userIds), status: MicrosoftUserStatus.CORRUPTED },
+    });
+    return new Set(rows.map((u) => u.id));
+  }
+
+  // ─── Health check helpers ───────────────────────────────────────────
+
+  /**
+   * Pure filter: returns subs whose expirationDateTime is within `hoursAhead` of now.
+   */
+  private filterExpiringSoon(
+    subs: OutlookWebhookSubscription[],
+    hoursAhead: number,
+  ): OutlookWebhookSubscription[] {
+    const threshold = new Date(Date.now() + hoursAhead * 3600 * 1000);
+    return subs.filter((sub) => sub.expirationDateTime < threshold);
+  }
+
+  /**
+   * Pure grouping: bucket subscriptions by their internal userId.
+   */
+  private groupByUserId(
+    subs: OutlookWebhookSubscription[],
+  ): Map<number, OutlookWebhookSubscription[]> {
+    const byUser = new Map<number, OutlookWebhookSubscription[]>();
+    for (const sub of subs) {
+      const bucket = byUser.get(sub.userId);
+      if (bucket) bucket.push(sub);
+      else byUser.set(sub.userId, [sub]);
+    }
+    return byUser;
+  }
+
+  /**
+   * Emit LIFECYCLE_MISSED for every sub whose last notification is older than 24 h.
+   * Returns the count of stale subs detected. No Graph calls.
+   */
+  private detectStaleSubscriptions(
+    subs: OutlookWebhookSubscription[],
+    correlationId: string,
+  ): number {
+    const staleThreshold = new Date(Date.now() - STALE_NOTIFICATION_THRESHOLD_HOURS * 3600 * 1000);
+    let staleDetected = 0;
+
+    for (const sub of subs) {
+      if (!sub.lastNotificationAt || sub.lastNotificationAt >= staleThreshold) continue;
+
+      this.logger.warn(
+        `[${correlationId}] Subscription ${sub.subscriptionId} has not received notifications since ${sub.lastNotificationAt.toISOString()}. Emitting LIFECYCLE_MISSED for delta sync.`
+      );
+
+      this.eventEmitter.emit(OutlookEventTypes.LIFECYCLE_MISSED, {
+        subscriptionId: sub.subscriptionId,
+        userId: sub.userId,
+        reason: 'health_check_stale',
+      });
+
+      staleDetected++;
+    }
+
+    return staleDetected;
+  }
+
+  /**
+   * Resolve one token for this user, then verify their subs in /$batch chunks of 20.
+   * A failure to obtain the token counts every sub for this user as failed.
+   */
+  private async verifySubscriptionsForUser(
+    userId: number,
+    userSubs: OutlookWebhookSubscription[],
+    correlationId: string,
+  ): Promise<HealthCheckCounters> {
+    const totals: HealthCheckCounters = { verified: 0, recreated: 0, renewed: 0, staleDetected: 0, failed: 0 };
+
+    let externalUserId: string;
+    let accessToken: string;
+    try {
+      externalUserId = await this.userIdConverter.internalToExternal(userId);
+      accessToken = await this.microsoftAuthService.getUserAccessToken({ internalUserId: userId });
+    } catch (error) {
+      totals.failed += userSubs.length;
+      this.logger.error(
+        `[${correlationId}] Token fetch failed for user ${userId}; skipping ${userSubs.length} sub(s):`,
+        error
+      );
+      return totals;
+    }
+
+    for (let offset = 0; offset < userSubs.length; offset += GRAPH_BATCH_SIZE) {
+      const chunk = userSubs.slice(offset, offset + GRAPH_BATCH_SIZE);
+      const chunkTotals = await this.verifySubscriptionsBatch(chunk, userId, externalUserId, accessToken, correlationId);
+      totals.verified += chunkTotals.verified;
+      totals.recreated += chunkTotals.recreated;
+      totals.renewed += chunkTotals.renewed;
+      totals.failed += chunkTotals.failed;
+    }
+
+    return totals;
+  }
+
+  /**
+   * Issue one /$batch POST for up to 20 subs belonging to the same user.
+   * Dispatches each inner response to `handleBatchResponseItem`.
+   */
+  private async verifySubscriptionsBatch(
+    chunk: OutlookWebhookSubscription[],
+    userId: number,
+    externalUserId: string,
+    accessToken: string,
+    correlationId: string,
+  ): Promise<HealthCheckCounters> {
+    const totals: HealthCheckCounters = { verified: 0, recreated: 0, renewed: 0, staleDetected: 0, failed: 0 };
+
+    await this.rateLimiter.acquirePermit(externalUserId);
+
+    const batchPayload: BatchRequestPayload = {
+      requests: chunk.map((sub, index) => ({
+        id: String(index),
+        method: 'GET',
+        url: `/subscriptions/${sub.subscriptionId}`,
+        headers: { 'Prefer': 'IdType="ImmutableId"' },
+      })),
+    };
+
+    try {
+      const response = await executeGraphApiCall(
+        () => axios.post<BatchResponsePayload<Subscription>>(
+          `${this.graphApiBaseUrl}/$batch`,
+          batchPayload,
+          {
+            headers: {
+              Authorization: `Bearer ${accessToken}`,
+              'Content-Type': 'application/json',
+            },
+          }
+        ),
+        {
+          logger: this.logger,
+          resourceName: `verify batch (user ${userId}, ${chunk.length} subs)`,
+          maxRetries: 2,
+        }
+      );
+
+      if (!response?.data) {
+        totals.failed += chunk.length;
+        this.logger.error(`[${correlationId}] Batch verify returned null for user ${userId}`);
+        return totals;
+      }
+
+      for (const item of response.data.responses) {
+        const sub = chunk[parseInt(item.id, 10)] as OutlookWebhookSubscription | undefined;
+        if (!sub) continue;
+        const itemTotals = await this.handleBatchResponseItem(sub, item, correlationId);
+        totals.verified += itemTotals.verified;
+        totals.recreated += itemTotals.recreated;
+        totals.renewed += itemTotals.renewed;
+        totals.failed += itemTotals.failed;
+      }
+    } catch (error) {
+      totals.failed += chunk.length;
+      this.logger.error(
+        `[${correlationId}] Batch verify failed for user ${userId} (${chunk.length} subs):`,
+        error
+      );
+    }
+
+    return totals;
+  }
+
+  /**
+   * Branch on one inner /$batch response: 200 (possibly renew), 404 (re-create), other (log).
+   */
+  private async handleBatchResponseItem(
+    sub: OutlookWebhookSubscription,
+    item: BatchResponse<Subscription>,
+    correlationId: string,
+  ): Promise<HealthCheckCounters> {
+    const totals: HealthCheckCounters = { verified: 0, recreated: 0, renewed: 0, staleDetected: 0, failed: 0 };
+
+    if (item.status === 200) {
+      totals.verified = 1;
+      if (await this.maybeRenewIfExpiringSoon(sub, item.body, correlationId)) {
+        totals.renewed = 1;
+      }
+      return totals;
+    }
+
+    if (item.status === 404) {
+      const result = await this.handleSubscriptionNotFoundAtMicrosoft(sub.subscriptionId, sub.userId, 'health_check_404', correlationId);
+      if (result === 'recreated') totals.recreated = 1;
+      else totals.failed = 1;
+      return totals;
+    }
+
+    totals.failed = 1;
+    this.logger.error(
+      `[${correlationId}] Unexpected status ${item.status} for sub ${sub.subscriptionId}: ${JSON.stringify(item.body)}`
+    );
+    return totals;
+  }
+
+  /**
+   * If the Graph-side expirationDateTime is within 12 h, trigger a renewal.
+   * Returns true iff a renewal was attempted.
+   */
+  private async maybeRenewIfExpiringSoon(
+    sub: OutlookWebhookSubscription,
+    graphSub: Subscription,
+    correlationId: string,
+  ): Promise<boolean> {
+    if (!graphSub.expirationDateTime) return false;
+
+    const expiration = new Date(graphSub.expirationDateTime);
+    const renewalThreshold = new Date(Date.now() + FORCE_RENEWAL_WINDOW_HOURS * 3600 * 1000);
+    if (expiration >= renewalThreshold) return false;
+
+    this.logger.log(
+      `[${correlationId}] Subscription ${sub.subscriptionId} expires within ${FORCE_RENEWAL_WINDOW_HOURS}h. Forcing renewal.`
+    );
+    try {
+      await this.renewWebhookSubscription(sub.subscriptionId, sub.userId);
+    } catch (error) {
+      // Swallow — renewWebhookSubscription already logs + emits events on failure.
+      this.logger.warn(
+        `[${correlationId}] Forced renewal of ${sub.subscriptionId} failed: ${error instanceof Error ? error.message : 'Unknown error'}`
+      );
+    }
+    return true;
+  }
+
+  /**
+   * Deactivate locally and attempt re-create. Emits SUBSCRIPTION_RECREATED or
+   * SUBSCRIPTION_RECREATION_FAILED. Used by both the renewal 404 handler and the
+   * health-check batch response handler.
+   */
+  private async handleSubscriptionNotFoundAtMicrosoft(
+    subscriptionId: string,
+    internalUserId: number,
+    reason: 'renewal_404' | 'health_check_404',
+    correlationId: string,
+  ): Promise<'recreated' | 'failed'> {
+    this.logger.warn(
+      `[${correlationId}] Subscription ${subscriptionId} not found at Microsoft. Deactivating and attempting re-creation.`
+    );
+
+    await this.webhookSubscriptionRepository.deactivateSubscription(subscriptionId);
+
+    try {
+      const externalUserId = await this.userIdConverter.internalToExternal(internalUserId);
+      await this.createWebhookSubscription(externalUserId);
+
+      this.logger.log(
+        `[${correlationId}] Successfully re-created subscription for user ${internalUserId} after 404`
+      );
+      this.eventEmitter.emit(OutlookEventTypes.SUBSCRIPTION_RECREATED, {
+        subscriptionId,
+        userId: internalUserId,
+        reason,
+      });
+      return 'recreated';
+    } catch (recreateError) {
+      const recreateMsg = recreateError instanceof Error ? recreateError.message : 'Unknown error';
+      this.logger.error(
+        `[${correlationId}] Failed to re-create subscription for user ${internalUserId}: ${recreateMsg}`
+      );
+      this.eventEmitter.emit(OutlookEventTypes.SUBSCRIPTION_RECREATION_FAILED, {
+        subscriptionId,
+        userId: internalUserId,
+        reason,
+        error: recreateMsg,
+      });
+      return 'failed';
     }
   }
 }


### PR DESCRIPTION
# Problem 

Sometimes the refresh_token of the user got revoked from outlook side in some cases.

# Changes:

to handle that we handle the error of `invalid_grant` by marking the user as `CORRUPTED` letting the host app know if the user needs to re-login again.