### PR TITLE
fix: reset subscirptions on fresh login

### DIFF
--- a/src/repositories/outlook-webhook-subscription.repository.ts
+++ b/src/repositories/outlook-webhook-subscription.repository.ts
@@ -101,6 +101,15 @@ export class OutlookWebhookSubscriptionRepository {
     return result;
   }
 
+  async findAllActiveByUserIdAndResource(
+    userId: number,
+    resource: string,
+  ): Promise<OutlookWebhookSubscription[]> {
+    return this.repository.find({
+      where: { userId, resource, isActive: true },
+    });
+  }
+
   async updateLastNotificationAt(subscriptionId: string): Promise<void> {
     await this.repository.update(
       { subscriptionId, isActive: true },

--- a/src/services/auth/microsoft-auth.service.ts
+++ b/src/services/auth/microsoft-auth.service.ts
@@ -676,6 +676,19 @@ export class MicrosoftAuthService {
 
       // Check if calendar.read permissions were requested
       if (this.hasCalendarSubscriptionPermission(scopes)) {
+        try {
+          this.logger.log(`[${correlationId}] Cleaning up existing calendar subscriptions before recreate`);
+          const cleanup = await this.subscriptionService
+            .cleanupSubscriptionsForUserAndResource(externalUserId, '/me/events');
+          this.logger.log(
+            `[${correlationId}] Calendar cleanup: found=${cleanup.totalFound}, deleted=${cleanup.successfullyDeleted}, failed=${cleanup.failedToDelete}`
+          );
+        } catch (cleanupError) {
+          this.logger.warn(
+            `[${correlationId}] Calendar cleanup failed, proceeding with creation: ${cleanupError instanceof Error ? cleanupError.message : 'Unknown error'}`
+          );
+        }
+
         // Create webhook subscription for the user's calendar with retry
         try {
           this.logger.log(`[${correlationId}] Creating calendar webhook subscription with retry logic`);
@@ -703,6 +716,19 @@ export class MicrosoftAuthService {
 
       // Check if email.read permissions were requested
       if (this.hasEmailSubscriptionPermission(scopes)) {
+        try {
+          this.logger.log(`[${correlationId}] Cleaning up existing email subscriptions before recreate`);
+          const cleanup = await this.subscriptionService
+            .cleanupSubscriptionsForUserAndResource(externalUserId, '/me/messages');
+          this.logger.log(
+            `[${correlationId}] Email cleanup: found=${cleanup.totalFound}, deleted=${cleanup.successfullyDeleted}, failed=${cleanup.failedToDelete}`
+          );
+        } catch (cleanupError) {
+          this.logger.warn(
+            `[${correlationId}] Email cleanup failed, proceeding with creation: ${cleanupError instanceof Error ? cleanupError.message : 'Unknown error'}`
+          );
+        }
+
         // Create webhook subscription for the user's email with retry
         try {
           this.logger.log(`[${correlationId}] Creating email webhook subscription with retry logic`);

--- a/src/services/subscription/microsoft-subscription.service.ts
+++ b/src/services/subscription/microsoft-subscription.service.ts
@@ -761,6 +761,49 @@ export class MicrosoftSubscriptionService {
   }
 
   /**
+   * Cleanup all active subscriptions for a user + resource, at Microsoft Graph
+   * and in the local DB. Leaves subs for other resources untouched.
+   *
+   * @param externalUserId - External user ID from the host application
+   * @param resource - Graph resource string (e.g. '/me/events', '/me/messages')
+   * @returns Result summary from the Graph-side cleanup pass
+   */
+  async cleanupSubscriptionsForUserAndResource(
+    externalUserId: string,
+    resource: string,
+  ): Promise<SubscriptionCleanupResult> {
+    const internalUserId = await this.userIdConverter.externalToInternal(
+      externalUserId,
+      { cache: false },
+    );
+    const accessToken = await this.microsoftAuthService.getUserAccessToken({
+      internalUserId,
+      cache: false,
+    });
+
+    this.logger.log(
+      `🧹 Cleaning up ${resource} subscriptions for user ${internalUserId}`,
+    );
+
+    const result = await this.cleanupSubscriptions({
+      accessToken,
+      filter: (sub) =>
+        sub.resource === resource &&
+        (sub.clientState?.includes(`user_${internalUserId}_`) || false),
+    });
+
+    const dbRows = await this.webhookSubscriptionRepository
+      .findAllActiveByUserIdAndResource(internalUserId, resource);
+    for (const row of dbRows) {
+      await this.webhookSubscriptionRepository.deactivateSubscription(
+        row.subscriptionId,
+      );
+    }
+
+    return result;
+  }
+
+  /**
    * Revoke Microsoft OAuth tokens
    * @param refreshToken - The refresh token to revoke
    */


### PR DESCRIPTION
# Problem:

On fresh login, the process has to correct the user subscription state. the subscription might be corrupted or losing the correct subscription state in the database. 

# Changes:

just cleanup any other active subcription in both sides (outlook provider - the database)

