### PR TITLE
fix: subscription decouple with auth

### DIFF
--- a/src/enums/event-types.enum.ts
+++ b/src/enums/event-types.enum.ts
@@ -33,4 +33,8 @@ export enum OutlookEventTypes {
 
   // Error events
   SUBSCRIPTION_CREATION_FAILED = 'outlook.subscription.creation_failed',
+
+  // Cron job observability events
+  HEALTH_CHECK_COMPLETED = 'outlook.cron.health_check.completed',
+  RETRY_FAILED_SUBSCRIPTIONS_COMPLETED = 'outlook.cron.retry_failed_subscriptions.completed',
 }

--- a/src/enums/microsoft-user-status.enum.ts
+++ b/src/enums/microsoft-user-status.enum.ts
@@ -1,4 +1,5 @@
 export enum MicrosoftUserStatus {
   ACTIVE = 'ACTIVE',
   CORRUPTED = 'CORRUPTED',
+  SUBSCRIPTION_FAILED = 'SUBSCRIPTION_FAILED',
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,6 +21,7 @@ export * from './interfaces/recurrence.interfaces';
 export * from './enums/permission-scope.enum';
 export * from './enums/event-types.enum';
 export * from './enums/show-as-type.enum';
+export * from './enums/microsoft-user-status.enum';
 
 // Export constants
 export * from './constants';

--- a/src/repositories/outlook-webhook-subscription.repository.ts
+++ b/src/repositories/outlook-webhook-subscription.repository.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository, MoreThan } from 'typeorm';
+import { Repository, MoreThan, In, Not } from 'typeorm';
 import { OutlookWebhookSubscription } from '../entities/outlook-webhook-subscription.entity';
 import { TtlCache } from '../utils/ttl-cache.util';
 
@@ -80,10 +80,31 @@ export class OutlookWebhookSubscriptionRepository {
     this.byUserId.clear();
   }
 
-  async findActiveSubscriptions(): Promise<OutlookWebhookSubscription[]> {
+  async findActiveSubscriptions(excludeUserIds?: number[]): Promise<OutlookWebhookSubscription[]> {
+    const now = new Date();
+    if (excludeUserIds && excludeUserIds.length > 0) {
+      return this.repository.find({
+        where: {
+          isActive: true,
+          expirationDateTime: MoreThan(now),
+          userId: Not(In(excludeUserIds)),
+        },
+      });
+    }
+    return this.repository.find({
+      where: {
+        isActive: true,
+        expirationDateTime: MoreThan(now),
+      },
+    });
+  }
+
+  async findActiveByUserIds(userIds: number[]): Promise<OutlookWebhookSubscription[]> {
+    if (userIds.length === 0) return [];
     const now = new Date();
     return this.repository.find({
       where: {
+        userId: In(userIds),
         isActive: true,
         expirationDateTime: MoreThan(now),
       },

--- a/src/services/auth/microsoft-auth.service.ts
+++ b/src/services/auth/microsoft-auth.service.ts
@@ -16,7 +16,7 @@ import { PermissionScope } from '../../enums/permission-scope.enum';
 import { InjectRepository } from '@nestjs/typeorm';
 import { FindOptionsWhere, Repository } from 'typeorm';
 import { MicrosoftUser } from '../../entities/microsoft-user.entity';
-import { retryWithBackoff } from '../../utils/retry.util';
+import { retryWithBackoff, isNonRetryableError } from '../../utils/retry.util';
 import { TtlCache } from '../../utils/ttl-cache.util';
 import { MailboxInactiveError } from '../../errors/mailbox-inactive.error';
 import { CsrfValidationError } from '../../errors/csrf-validation.error';
@@ -569,9 +569,15 @@ export class MicrosoftAuthService {
         }),
       );
 
-      // Setup subscriptions (both calendar and email)
-      this.logger.log(`[${correlationId}] Starting subscription setup (async)`);
-      await this.setupSubscriptions(stateData.userId, scopesToUse);
+      // Setup subscriptions in background (fire-and-forget)
+      // Errors are handled inside setupSubscriptions via SUBSCRIPTION_CREATION_FAILED events.
+      // The 6-hour cron health check acts as safety net for any missed subscriptions.
+      this.logger.log(`[${correlationId}] Starting subscription setup (background)`);
+      this.setupSubscriptions(stateData.userId, scopesToUse).catch((err: unknown) => {
+        this.logger.error(
+          `[${correlationId}] Background subscription setup failed: ${err instanceof Error ? err.message : String(err)}`
+        );
+      });
 
       this.logger.log(`[${correlationId}] Token exchange completed successfully`);
       return tokenData;
@@ -652,6 +658,27 @@ export class MicrosoftAuthService {
   }
 
   /**
+   * Marks a Microsoft user as SUBSCRIPTION_FAILED when subscription creation
+   * encounters a non-retryable error (401, 403, 404, 410). The daily retry
+   * cron can use this status to attempt re-creation later.
+   */
+  private async markSubscriptionFailed(externalUserId: string, correlationId: string): Promise<void> {
+    try {
+      await this.microsoftUserRepository.update(
+        { externalUserId } as FindOptionsWhere<MicrosoftUser>,
+        { status: MicrosoftUserStatus.SUBSCRIPTION_FAILED },
+      );
+      this.logger.warn(
+        `[${correlationId}] Marked user ${externalUserId} as SUBSCRIPTION_FAILED due to non-retryable error`
+      );
+    } catch (err) {
+      this.logger.error(
+        `[${correlationId}] Failed to update status for user ${externalUserId}: ${err instanceof Error ? err.message : String(err)}`
+      );
+    }
+  }
+
+  /**
    * Setup webhook subscriptions for a user based on requested scopes
    * @param externalUserId - External user ID from the host application
    * @param scopes - Requested permission scopes
@@ -696,22 +723,30 @@ export class MicrosoftAuthService {
           await retryWithBackoff(
             () => this.subscriptionService.createWebhookSubscription(externalUserId),
             {
-              maxRetries: 7,
-              retryDelayMs: 1000
+              maxRetries: 3,
+              retryDelayMs: 1000,
+              logger: this.logger,
+              operationName: `create webhook subscription for user ${externalUserId}`,
             }
           );
           this.logger.log(`[${correlationId}] Successfully created calendar webhook subscription for user ${externalUserId}`);
         } catch (calendarError) {
-          // Don't fail authentication if webhook creation fails
           const errorMsg = `Failed to create calendar webhook subscription after retries: ${calendarError instanceof Error ? calendarError.message : 'Unknown error'}`;
           this.logger.error(`[${correlationId}] ${errorMsg}`);
           errors.push(errorMsg);
+
+          const nonRetryable = isNonRetryableError(calendarError);
 
           this.eventEmitter.emit(OutlookEventTypes.SUBSCRIPTION_CREATION_FAILED, {
             userId: externalUserId,
             subscriptionType: 'calendar',
             error: errorMsg,
+            isNonRetryable: nonRetryable,
           });
+
+          if (nonRetryable) {
+            await this.markSubscriptionFailed(externalUserId, correlationId);
+          }
         }
       }
 
@@ -736,22 +771,30 @@ export class MicrosoftAuthService {
           await retryWithBackoff(
             () => this.emailService.createWebhookSubscription(externalUserId),
             {
-              maxRetries: 7,
-              retryDelayMs: 1000
+              maxRetries: 3,
+              retryDelayMs: 1000,
+              logger: this.logger,
+              operationName: `create email subscription for user ${externalUserId}`,
             }
           );
           this.logger.log(`[${correlationId}] Successfully created email webhook subscription for user ${externalUserId}`);
         } catch (emailError) {
-          // Don't fail authentication if webhook creation fails
           const errorMsg = `Failed to create email webhook subscription after retries: ${emailError instanceof Error ? emailError.message : 'Unknown error'}`;
           this.logger.error(`[${correlationId}] ${errorMsg}`);
           errors.push(errorMsg);
+
+          const nonRetryable = isNonRetryableError(emailError);
 
           this.eventEmitter.emit(OutlookEventTypes.SUBSCRIPTION_CREATION_FAILED, {
             userId: externalUserId,
             subscriptionType: 'email',
             error: errorMsg,
+            isNonRetryable: nonRetryable,
           });
+
+          if (nonRetryable) {
+            await this.markSubscriptionFailed(externalUserId, correlationId);
+          }
         }
       }
 

--- a/src/services/shared/user-id-converter.service.ts
+++ b/src/services/shared/user-id-converter.service.ts
@@ -60,6 +60,7 @@ export class UserIdConverterService {
     }
 
     const user = await this.microsoftUserRepository.findOne({
+      select: ['id'],
       where: { externalUserId },
     });
 
@@ -97,6 +98,7 @@ export class UserIdConverterService {
     }
 
     const user = await this.microsoftUserRepository.findOne({
+      select: ['externalUserId'],
       where: { id: internalUserId },
     });
 

--- a/src/services/subscription/microsoft-subscription.service.ts
+++ b/src/services/subscription/microsoft-subscription.service.ts
@@ -3,7 +3,7 @@ import { Injectable, Logger, Inject, forwardRef } from '@nestjs/common';
 import { EventEmitter2 } from '@nestjs/event-emitter';
 import { Cron } from '@nestjs/schedule';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository, Not, In } from 'typeorm';
+import { Repository, Not } from 'typeorm';
 import axios from 'axios';
 import { Subscription, BatchRequestPayload, BatchResponsePayload, BatchResponse } from '../../types';
 import { MicrosoftAuthService } from '../auth/microsoft-auth.service';
@@ -878,26 +878,27 @@ export class MicrosoftSubscriptionService {
     const correlationId = `health-check-${Date.now()}`;
 
     try {
-      const allActiveSubs = await this.webhookSubscriptionRepository.findActiveSubscriptions();
+      // Find CORRUPTED users first so we can exclude their subs from the query
+      // instead of loading all subs then filtering in-memory.
+      const corruptedUsers = await this.microsoftUserRepository.find({
+        select: ['id'],
+        where: { status: MicrosoftUserStatus.CORRUPTED },
+      });
+      const corruptedUserIds = corruptedUsers.map((u) => u.id);
 
-      if (allActiveSubs.length === 0) {
-        this.logger.debug(`[${correlationId}] No active subscriptions to verify`);
-        return;
+      if (corruptedUserIds.length > 0) {
+        this.logger.log(
+          `[${correlationId}] Excluding ${corruptedUserIds.length} CORRUPTED user(s) from health check`
+        );
       }
 
-      // Skip subs whose owning user is CORRUPTED — any outbound Graph work for
-      // them would just trigger the same invalid_grant and we've already signalled
-      // the host app to prompt re-auth.
-      const corruptedUserIds = await this.findCorruptedUserIds(allActiveSubs);
-      const activeSubs = corruptedUserIds.size > 0
-        ? allActiveSubs.filter((sub) => !corruptedUserIds.has(sub.userId))
-        : allActiveSubs;
+      const activeSubs = await this.webhookSubscriptionRepository.findActiveSubscriptions(
+        corruptedUserIds.length > 0 ? corruptedUserIds : undefined
+      );
 
-      const skipped = allActiveSubs.length - activeSubs.length;
-      if (skipped > 0) {
-        this.logger.log(
-          `[${correlationId}] Skipping ${skipped} sub(s) owned by ${corruptedUserIds.size} CORRUPTED user(s)`
-        );
+      if (activeSubs.length === 0) {
+        this.logger.debug(`[${correlationId}] No active subscriptions to verify`);
+        return;
       }
 
       const expiringSoon = this.filterExpiringSoon(activeSubs, HEALTH_CHECK_WINDOW_HOURS);
@@ -924,26 +925,88 @@ export class MicrosoftSubscriptionService {
       this.logger.log(
         `[${correlationId}] Health check complete: ${counters.verified} verified, ${counters.recreated} recreated, ${counters.renewed} renewed, ${counters.staleDetected} stale-detected, ${counters.failed} failed`
       );
+
+      this.eventEmitter.emit(OutlookEventTypes.HEALTH_CHECK_COMPLETED, {
+        correlationId,
+        totalActive: activeSubs.length,
+        corruptedUsersExcluded: corruptedUserIds.length,
+        ...counters,
+      });
     } catch (error) {
       this.logger.error(`[${correlationId}] Subscription health check job failed:`, error);
     }
   }
 
   /**
-   * Return the set of user IDs whose MicrosoftUser.status === CORRUPTED among
-   * the owners of the given subs. One indexed query, no N+1.
+   * Daily retry for users whose subscription creation failed with a non-retryable
+   * error during auth. Finds SUBSCRIPTION_FAILED users with no active webhook
+   * subscriptions and attempts to recreate them.
    */
-  private async findCorruptedUserIds(
-    subs: OutlookWebhookSubscription[],
-  ): Promise<Set<number>> {
-    const userIds = Array.from(new Set(subs.map((s) => s.userId)));
-    if (userIds.length === 0) return new Set();
+  @Cron('0 3 * * *')
+  async retryFailedSubscriptions(): Promise<void> {
+    const correlationId = `retry-failed-subs-${Date.now()}`;
+    try {
+      const failedUsers = await this.microsoftUserRepository.find({
+        where: {
+          status: MicrosoftUserStatus.SUBSCRIPTION_FAILED,
+          isActive: true,
+        },
+      });
 
-    const rows = await this.microsoftUserRepository.find({
-      select: ['id'],
-      where: { id: In(userIds), status: MicrosoftUserStatus.CORRUPTED },
-    });
-    return new Set(rows.map((u) => u.id));
+      if (failedUsers.length === 0) {
+        this.logger.debug(`[${correlationId}] No SUBSCRIPTION_FAILED users to retry`);
+        return;
+      }
+
+      const failedUserIds = failedUsers.map((u) => u.id);
+      const activeSubs = await this.webhookSubscriptionRepository.findActiveByUserIds(failedUserIds);
+      const usersWithActiveSubs = new Set(activeSubs.map((s) => s.userId));
+
+      const usersToRetry = failedUsers.filter((u) => !usersWithActiveSubs.has(u.id));
+
+      this.logger.log(
+        `[${correlationId}] Retrying subscriptions: ${failedUsers.length} SUBSCRIPTION_FAILED, ` +
+        `${failedUsers.length - usersToRetry.length} already have subs, ${usersToRetry.length} to retry`
+      );
+
+      let succeeded = 0;
+      let failed = 0;
+
+      for (const user of usersToRetry) {
+        try {
+          await this.createWebhookSubscription(user.externalUserId);
+          await this.microsoftUserRepository.update(
+            { id: user.id },
+            { status: MicrosoftUserStatus.ACTIVE },
+          );
+          succeeded++;
+          this.logger.log(
+            `[${correlationId}] Recreated subscription for user ${user.externalUserId}, status reset to ACTIVE`
+          );
+        } catch (err) {
+          failed++;
+          this.logger.warn(
+            `[${correlationId}] Failed to recreate subscription for user ${user.externalUserId}: ` +
+            (err instanceof Error ? err.message : String(err))
+          );
+        }
+      }
+
+      this.logger.log(
+        `[${correlationId}] Retry complete: ${succeeded} succeeded, ${failed} failed`
+      );
+
+      this.eventEmitter.emit(OutlookEventTypes.RETRY_FAILED_SUBSCRIPTIONS_COMPLETED, {
+        correlationId,
+        totalFailed: failedUsers.length,
+        alreadyHaveSubs: failedUsers.length - usersToRetry.length,
+        attempted: usersToRetry.length,
+        succeeded,
+        failed,
+      });
+    } catch (error) {
+      this.logger.error(`[${correlationId}] Retry failed subscriptions job failed:`, error);
+    }
   }
 
   // ─── Health check helpers ───────────────────────────────────────────


### PR DESCRIPTION
1. Fire-and-forget subscription setup
exchangeCodeForToken() no longer awaits setupSubscriptions() — it runs in the background with a .catch() safety net
Auth callback now returns in <2s instead of potentially 120s
2. Circuit breaker with SUBSCRIPTION_FAILED status
New MicrosoftUserStatus.SUBSCRIPTION_FAILED enum value
When subscription creation fails with a non-retryable error (401/403/404/410), the user is marked SUBSCRIPTION_FAILED
Transient errors (429/5xx) do NOT trigger the status change — those are left for the cron safety net
isNonRetryable boolean added to SUBSCRIPTION_CREATION_FAILED event payload

3. Daily retry cron for failed subscriptions
New @Cron('0 3 * * *') — runs daily at 3 AM UTC
Finds SUBSCRIPTION_FAILED users with no active webhook subscriptions
Attempts createWebhookSubscription(), resets status to ACTIVE on success
Processes sequentially to avoid stacking 429s

4. Health check refactor
verifySubscriptionHealth now queries corrupted users first, then fetches active subs excluding them at the DB level (instead of loading all subs then filtering in-memory)
Removed findCorruptedUserIds() helper (replaced by direct query)

5. Cron observability events
HEALTH_CHECK_COMPLETED — emitted after the 6-hour health check with counters
RETRY_FAILED_SUBSCRIPTIONS_COMPLETED — emitted after the daily retry with success/failure counts

6. Repository improvements
findActiveSubscriptions(excludeUserIds?) — optional exclusion filter at DB level
findActiveByUserIds(userIds) — scoped query for specific users only
UserIdConverterService — added select clauses to avoid loading full token data

7. Export MicrosoftUserStatus enum
Now exported from package index so host apps can query/react to SUBSCRIPTION_FAILED