### PR TITLE
fix: webhook authorization + testing

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -3,9 +3,12 @@ import eslintPluginComments from '@eslint-community/eslint-plugin-eslint-comment
 import eslintPluginImport from 'eslint-plugin-import';
 
 export default tseslint.config(
+  // Global ignores (must be standalone object with only 'ignores' key)
+  {
+    ignores: ['*.mjs', '*.cjs', '*.js', 'dist/**', 'src/mock/**'],
+  },
   tseslint.configs.strictTypeChecked,
   {
-    ignores: ['*.mjs', '*.cjs', '*.js', 'dist/**'],
     plugins: {
       'eslint-comments': eslintPluginComments,
       'import': eslintPluginImport,

--- a/package-lock.json
+++ b/package-lock.json
@@ -66,6 +66,35 @@
         "typeorm": "^0.3.0"
       }
     },
+    ".yalc/@checkfirst/nestjs-outlook": {
+      "version": "9.1.0",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "@checkfirst/nestjs-outlook": "file:.yalc/@checkfirst/nestjs-outlook",
+        "@microsoft/microsoft-graph-client": "^3.0.7",
+        "@microsoft/microsoft-graph-types": "^2.40.0",
+        "axios": "^1.6.0",
+        "class-validator": "^0.14.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/checkfirst-ltd"
+      },
+      "peerDependencies": {
+        "@nestjs/common": "^8.0.0 || ^9.0.0 || ^10.0.0",
+        "@nestjs/core": "^8.0.0 || ^9.0.0 || ^10.0.0",
+        "@nestjs/event-emitter": "^2.0.0",
+        "@nestjs/schedule": "^2.0.0 || ^3.0.0 || ^4.0.0",
+        "@nestjs/typeorm": "^8.0.0 || ^9.0.0 || ^10.0.0",
+        "reflect-metadata": "^0.1.13 || ^0.2.0",
+        "rxjs": "^7.0.0",
+        "typeorm": "^0.3.0"
+      }
+    },
+    ".yalc/@checkfirst/nestjs-outlook/.yalc/@checkfirst/nestjs-outlook": {
+      "extraneous": true
+    },
     "node_modules/@ampproject/remapping": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",

--- a/src/controllers/calendar.controller.spec.ts
+++ b/src/controllers/calendar.controller.spec.ts
@@ -1,10 +1,14 @@
 import { Test } from "@nestjs/testing";
+import { EventEmitter2 } from "@nestjs/event-emitter";
 import { Response } from "express";
 import { CalendarController } from "./calendar.controller";
 import { CalendarService } from "../services/calendar/calendar.service";
 import { LifecycleEventHandlerService } from "../services/calendar/lifecycle-event-handler.service";
 import { OutlookWebhookNotificationDto } from "../dto/outlook-webhook-notification.dto";
-import { WebhookClientStateGuard } from "../guards/webhook-client-state.guard";
+import {
+  WebhookClientStateGuard,
+  WebhookValidationResult,
+} from "../guards/webhook-client-state.guard";
 import { OutlookWebhookSubscriptionRepository } from "../repositories/outlook-webhook-subscription.repository";
 
 function makeRes(): jest.Mocked<Response> {
@@ -18,6 +22,11 @@ function makeRes(): jest.Mocked<Response> {
 }
 
 const req = {} as never;
+
+/** Build a request carrying the guard's verdict, as the controller reads it. */
+function reqWithValidation(validation: WebhookValidationResult) {
+  return { webhookValidation: validation } as never;
+}
 
 function calendarItem(overrides: Record<string, unknown> = {}) {
   return {
@@ -65,6 +74,7 @@ describe("CalendarController (webhook receiving)", () => {
           provide: OutlookWebhookSubscriptionRepository,
           useValue: { findBySubscriptionId: jest.fn() },
         },
+        { provide: EventEmitter2, useValue: { emit: jest.fn() } },
         WebhookClientStateGuard,
       ],
     }).compile();
@@ -199,6 +209,84 @@ describe("CalendarController (webhook receiving)", () => {
       await controller.handleCalendarWebhook("", body, req, res);
 
       expect(res.status).toHaveBeenCalledWith(202);
+    });
+  });
+
+  describe("honors WebhookClientStateGuard verdict (stop processing)", () => {
+    it("does not process an item the guard marked invalid, and still returns 200", async () => {
+      const res = makeRes();
+      const body = {
+        value: [calendarItem()],
+      } as unknown as OutlookWebhookNotificationDto;
+      const guardedReq = reqWithValidation({
+        valid: false,
+        invalidItems: [
+          { index: 0, valid: false, reason: "client_state_mismatch" },
+        ],
+      });
+
+      await controller.handleCalendarWebhookNotification(
+        "",
+        body,
+        guardedReq,
+        res,
+      );
+
+      expect(calendarService.handleOutlookWebhookV2).not.toHaveBeenCalled();
+      expect(res.status).not.toHaveBeenCalledWith(500);
+      expect(res.json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          success: true,
+          message: expect.stringContaining("Rejected"),
+        }),
+      );
+    });
+
+    it("processes only the authorized items in a mixed batch", async () => {
+      const res = makeRes();
+      const body = {
+        value: [
+          calendarItem({ subscriptionId: "forged" }),
+          calendarItem({ subscriptionId: "legit" }),
+        ],
+      } as unknown as OutlookWebhookNotificationDto;
+      const guardedReq = reqWithValidation({
+        valid: false,
+        invalidItems: [
+          { index: 0, valid: false, reason: "unknown_subscription" },
+        ],
+      });
+
+      await controller.handleCalendarWebhookNotification(
+        "",
+        body,
+        guardedReq,
+        res,
+      );
+
+      expect(calendarService.handleOutlookWebhookV2).toHaveBeenCalledTimes(1);
+      const [mapped] = calendarService.handleOutlookWebhookV2.mock.calls[0];
+      expect(mapped).toMatchObject({ subscriptionId: "legit" });
+    });
+
+    it("legacy /webhook also skips invalid items", async () => {
+      const res = makeRes();
+      const body = {
+        value: [calendarItem()],
+      } as unknown as OutlookWebhookNotificationDto;
+      const guardedReq = reqWithValidation({
+        valid: false,
+        invalidItems: [
+          { index: 0, valid: false, reason: "missing_subscription_id" },
+        ],
+      });
+
+      await controller.handleCalendarWebhook("", body, guardedReq, res);
+
+      expect(calendarService.handleOutlookWebhook).not.toHaveBeenCalled();
+      expect(res.json).toHaveBeenCalledWith(
+        expect.objectContaining({ success: true }),
+      );
     });
   });
 });

--- a/src/controllers/calendar.controller.ts
+++ b/src/controllers/calendar.controller.ts
@@ -7,7 +7,7 @@ import { ChangeNotification, ChangeType } from '@microsoft/microsoft-graph-types
 import { OutlookWebhookNotificationDto } from '../dto/outlook-webhook-notification.dto';
 import { validateNotificationItem, validateChangeType, WebhookResourceType } from '../utils/webhook-notification.validator';
 import { LifecycleEventHandlerService } from '../services/calendar/lifecycle-event-handler.service';
-import { WebhookClientStateGuard } from '../guards/webhook-client-state.guard';
+import { WebhookClientStateGuard, RequestWithWebhookValidation } from '../guards/webhook-client-state.guard';
 
 @ApiTags('Calendar')
 @Controller('calendar')
@@ -81,38 +81,36 @@ export class CalendarController {
       this.logger.log(`[WEBHOOK_RECEIVED] webhookTraceId=${webhookTraceId}, endpoint=notification, notificationCount=${notificationBody.value.length}`);
       this.logger.debug(`Received webhook notification: ${JSON.stringify(notificationBody)}`);
 
+      // Drop items rejected by WebhookClientStateGuard (clientState / subscription security check)
+      const { authorized, rejectedCount } = this.filterAuthorizedItems(
+        req as RequestWithWebhookValidation,
+        Array.isArray(notificationBody.value) ? notificationBody.value : [],
+      );
+      if (rejectedCount > 0) {
+        this.logger.warn(`[SECURITY] Skipping ${rejectedCount.toString()} rejected webhook item(s), webhookTraceId=${webhookTraceId}`);
+      }
+
+      // Every item failed the security check - acknowledge with 200 but process nothing
+      if (authorized.length === 0) {
+        res.json({
+          success: true,
+          message: rejectedCount > 0
+            ? `Rejected ${rejectedCount.toString()} notification(s) failing security validation`
+            : `Received webhook notification with unexpected format`,
+        });
+        return;
+      }
+
       // Early response with 202 Accepted if we have multiple notifications
       // This follows Microsoft's best practice to avoid timing out on the response
-      if (Array.isArray(notificationBody.value) && notificationBody.value.length > 2) {
-        this.logger.log(`Received batch of ${notificationBody.value.length.toString()} notifications, responding with 202 Accepted`);
+      if (authorized.length > 2) {
+        this.logger.log(`Received batch of ${authorized.length.toString()} notifications, responding with 202 Accepted`);
         res.status(202).json({
           success: true,
           message: 'Notifications accepted for processing',
         });
 
-        if (Array.isArray(notificationBody.value) && notificationBody.value.length > 0) {
-          for (const item of notificationBody.value) {
-            await this.calendarService.handleOutlookWebhookV2({
-              subscriptionId: item.subscriptionId,
-              subscriptionExpirationDateTime: item.subscriptionExpirationDateTime,
-              changeType: item.changeType as ChangeType,
-              resource: item.resource,
-              resourceData: item.resourceData,
-              clientState: item.clientState,
-              tenantId: item.tenantId,
-            }, webhookTraceId);
-          }
-          res.json({
-            success: true,
-            message: `Notifications accepted for processing`,
-          });
-          return;
-        }
-      }
-
-      // For smaller batches, process synchronously
-      if (Array.isArray(notificationBody.value) && notificationBody.value.length > 0) {
-        for (const item of notificationBody.value) {
+        for (const item of authorized) {
           await this.calendarService.handleOutlookWebhookV2({
             subscriptionId: item.subscriptionId,
             subscriptionExpirationDateTime: item.subscriptionExpirationDateTime,
@@ -123,18 +121,24 @@ export class CalendarController {
             tenantId: item.tenantId,
           }, webhookTraceId);
         }
-        res.json({
-          success: true,
-          message: `Processed ${notificationBody.value.length.toString()} notifications`,
-        });
         return;
       }
 
-      // Handle empty or unexpected notification format
-      this.logger.warn('Received webhook notification with unexpected format');
+      // For smaller batches, process synchronously
+      for (const item of authorized) {
+        await this.calendarService.handleOutlookWebhookV2({
+          subscriptionId: item.subscriptionId,
+          subscriptionExpirationDateTime: item.subscriptionExpirationDateTime,
+          changeType: item.changeType as ChangeType,
+          resource: item.resource,
+          resourceData: item.resourceData,
+          clientState: item.clientState,
+          tenantId: item.tenantId,
+        }, webhookTraceId);
+      }
       res.json({
         success: true,
-        message: `Received webhook notification with unexpected format`,
+        message: `Processed ${authorized.length.toString()} notifications`,
       });
     } catch (error: unknown) {
       const errorMessage = error instanceof Error ? error.message : String(error);
@@ -208,17 +212,37 @@ export class CalendarController {
       this.logger.log(`[WEBHOOK_RECEIVED] webhookTraceId=${webhookTraceId}, endpoint=webhook, notificationCount=${notificationBody.value.length}`);
       this.logger.debug(`Received webhook notification: ${JSON.stringify(notificationBody)}`);
 
+      // Drop items rejected by WebhookClientStateGuard (clientState / subscription security check)
+      const { authorized, rejectedCount } = this.filterAuthorizedItems(
+        req as RequestWithWebhookValidation,
+        Array.isArray(notificationBody.value) ? notificationBody.value : [],
+      );
+      if (rejectedCount > 0) {
+        this.logger.warn(`[SECURITY] Skipping ${rejectedCount.toString()} rejected webhook item(s), webhookTraceId=${webhookTraceId}`);
+      }
+
+      // Every item failed the security check - acknowledge with 200 but process nothing
+      if (authorized.length === 0) {
+        res.json({
+          success: true,
+          message: rejectedCount > 0
+            ? `Rejected ${rejectedCount.toString()} notification(s) failing security validation`
+            : `Received webhook notification with unexpected format`,
+        });
+        return;
+      }
+
       // Early response with 202 Accepted if we have multiple notifications
       // This follows Microsoft's best practice to avoid timing out on the response
-      if (Array.isArray(notificationBody.value) && notificationBody.value.length > 2) {
-        this.logger.log(`Received batch of ${notificationBody.value.length.toString()} notifications, responding with 202 Accepted`);
+      if (authorized.length > 2) {
+        this.logger.log(`Received batch of ${authorized.length.toString()} notifications, responding with 202 Accepted`);
         res.status(202).json({
           success: true,
           message: 'Notifications accepted for processing',
         });
 
         // Process notifications asynchronously after sending the response
-        this.processCalendarNotificationBatch(notificationBody, webhookTraceId).catch((error: unknown) => {
+        this.processCalendarNotificationBatch(authorized, webhookTraceId).catch((error: unknown) => {
           const errorMessage = error instanceof Error ? error.message : String(error);
           this.logger.error(`Error processing notification batch: ${errorMessage}`);
         });
@@ -226,20 +250,10 @@ export class CalendarController {
       }
 
       // For smaller batches, process synchronously
-      if (Array.isArray(notificationBody.value) && notificationBody.value.length > 0) {
-        const results = await this.processCalendarNotificationBatch(notificationBody, webhookTraceId);
-        res.json({
-          success: true,
-          message: `Processed ${results.successCount.toString()} out of ${notificationBody.value.length.toString()} notifications`,
-        });
-        return;
-      }
-
-      // Handle empty or unexpected notification format
-      this.logger.warn('Received webhook notification with unexpected format');
+      const results = await this.processCalendarNotificationBatch(authorized, webhookTraceId);
       res.json({
         success: true,
-        message: `Received webhook notification with unexpected format`,
+        message: `Processed ${results.successCount.toString()} out of ${authorized.length.toString()} notifications`,
       });
     } catch (error: unknown) {
       const errorMessage = error instanceof Error ? error.message : String(error);
@@ -253,13 +267,36 @@ export class CalendarController {
   }
 
   /**
+   * Filter out notification items rejected by {@link WebhookClientStateGuard}.
+   *
+   * The guard returns 200 (so Microsoft stops retrying) but marks invalid items on the request.
+   * This drops those items so they are never processed, while authorized items proceed normally.
+   *
+   * @param req Request carrying the guard's `webhookValidation` verdict
+   * @param items The notification items in their original order
+   * @returns The authorized items and how many were rejected
+   */
+  private filterAuthorizedItems<T>(
+    req: RequestWithWebhookValidation,
+    items: T[],
+  ): { authorized: T[]; rejectedCount: number } {
+    const validation = req.webhookValidation;
+    if (!validation || validation.valid || validation.invalidItems.length === 0) {
+      return { authorized: items, rejectedCount: 0 };
+    }
+    const invalidIndexes = new Set(validation.invalidItems.map((i) => i.index));
+    const authorized = items.filter((_, idx) => !invalidIndexes.has(idx));
+    return { authorized, rejectedCount: items.length - authorized.length };
+  }
+
+  /**
    * Process a batch of calendar notifications asynchronously
-   * @param notificationBody The batch of notifications to process
+   * @param items The notification items to process (already filtered for authorization)
    * @param webhookTraceId Correlation ID for tracing this webhook through downstream operations
    * @returns Results of the processing operation
    */
   private async processCalendarNotificationBatch(
-    notificationBody: OutlookWebhookNotificationDto,
+    items: OutlookWebhookNotificationDto['value'],
     webhookTraceId: string,
   ): Promise<{ successCount: number; failureCount: number }> {
     // Track processing results
@@ -270,7 +307,7 @@ export class CalendarController {
     const processedEvents = new Set<string>();
 
     // Process each notification in the batch
-    for (const item of notificationBody.value) {
+    for (const item of items) {
       // Validate the notification item
       const validation = validateNotificationItem(
         item,

--- a/src/controllers/email.controller.ts
+++ b/src/controllers/email.controller.ts
@@ -5,7 +5,7 @@ import { EmailService } from '../services/email/email.service';
 import { ChangeNotification, ChangeType } from '@microsoft/microsoft-graph-types';
 import { OutlookWebhookNotificationDto } from '../dto/outlook-webhook-notification.dto';
 import { validateNotificationItem, validateChangeType, WebhookResourceType } from '../utils/webhook-notification.validator';
-import { WebhookClientStateGuard } from '../guards/webhook-client-state.guard';
+import { WebhookClientStateGuard, RequestWithWebhookValidation } from '../guards/webhook-client-state.guard';
 
 @ApiTags('Email')
 @Controller('email')
@@ -73,39 +73,49 @@ export class EmailController {
     // Process notification
     try {
       this.logger.debug(`Received email webhook notification: ${JSON.stringify(notificationBody)}`);
-      
+
+      // Drop items rejected by WebhookClientStateGuard (clientState / subscription security check)
+      const { authorized, rejectedCount } = this.filterAuthorizedItems(
+        req as RequestWithWebhookValidation,
+        Array.isArray(notificationBody.value) ? notificationBody.value : [],
+      );
+      if (rejectedCount > 0) {
+        this.logger.warn(`[SECURITY] Skipping ${rejectedCount.toString()} rejected email webhook item(s)`);
+      }
+
+      // Every item failed the security check - acknowledge with 200 but process nothing
+      if (authorized.length === 0) {
+        res.json({
+          success: true,
+          message: rejectedCount > 0
+            ? `Rejected ${rejectedCount.toString()} email notification(s) failing security validation`
+            : `Received email webhook notification with unexpected format`,
+        });
+        return;
+      }
+
       // Early response with 202 Accepted if we have multiple notifications
       // This follows Microsoft's best practice to avoid timing out on the response
-      if (Array.isArray(notificationBody.value) && notificationBody.value.length > 2) {
-        this.logger.log(`Received batch of ${notificationBody.value.length.toString()} email notifications, responding with 202 Accepted`);
+      if (authorized.length > 2) {
+        this.logger.log(`Received batch of ${authorized.length.toString()} email notifications, responding with 202 Accepted`);
         res.status(202).json({
           success: true,
           message: 'Email notifications accepted for processing',
         });
-        
+
         // Process notifications asynchronously after sending the response
-        this.processEmailNotificationBatch(notificationBody).catch((error: unknown) => {
+        this.processEmailNotificationBatch(authorized).catch((error: unknown) => {
           const errorMessage = error instanceof Error ? error.message : String(error);
           this.logger.error(`Error processing email notification batch: ${errorMessage}`);
         });
         return;
       }
-      
-      // For smaller batches, process synchronously
-      if (Array.isArray(notificationBody.value) && notificationBody.value.length > 0) {
-        const results = await this.processEmailNotificationBatch(notificationBody);
-        res.json({
-          success: true,
-          message: `Processed ${results.successCount.toString()} out of ${notificationBody.value.length.toString()} email notifications`,
-        });
-        return;
-      }
 
-      // Handle empty or unexpected notification format
-      this.logger.warn('Received email webhook notification with unexpected format');
+      // For smaller batches, process synchronously
+      const results = await this.processEmailNotificationBatch(authorized);
       res.json({
         success: true,
-        message: `Received email webhook notification with unexpected format`,
+        message: `Processed ${results.successCount.toString()} out of ${authorized.length.toString()} email notifications`,
       });
     } catch (error: unknown) {
       const errorMessage = error instanceof Error ? error.message : String(error);
@@ -119,22 +129,45 @@ export class EmailController {
   }
   
   /**
+   * Filter out notification items rejected by {@link WebhookClientStateGuard}.
+   *
+   * The guard returns 200 (so Microsoft stops retrying) but marks invalid items on the request.
+   * This drops those items so they are never processed, while authorized items proceed normally.
+   *
+   * @param req Request carrying the guard's `webhookValidation` verdict
+   * @param items The notification items in their original order
+   * @returns The authorized items and how many were rejected
+   */
+  private filterAuthorizedItems<T>(
+    req: RequestWithWebhookValidation,
+    items: T[],
+  ): { authorized: T[]; rejectedCount: number } {
+    const validation = req.webhookValidation;
+    if (!validation || validation.valid || validation.invalidItems.length === 0) {
+      return { authorized: items, rejectedCount: 0 };
+    }
+    const invalidIndexes = new Set(validation.invalidItems.map((i) => i.index));
+    const authorized = items.filter((_, idx) => !invalidIndexes.has(idx));
+    return { authorized, rejectedCount: items.length - authorized.length };
+  }
+
+  /**
    * Process a batch of email notifications asynchronously
-   * @param notificationBody The batch of notifications to process
+   * @param items The notification items to process (already filtered for authorization)
    * @returns Results of the processing operation
    */
   private async processEmailNotificationBatch(
-    notificationBody: OutlookWebhookNotificationDto,
+    items: OutlookWebhookNotificationDto['value'],
   ): Promise<{ successCount: number; failureCount: number }> {
     // Track processing results
     let successCount = 0;
     let failureCount = 0;
-    
+
     // Track processed message IDs to avoid duplicates
     const processedMessages = new Set<string>();
-    
+
     // Process each notification in the batch
-    for (const item of notificationBody.value) {
+    for (const item of items) {
       // Validate the notification item
       const validation = validateNotificationItem(
         item,

--- a/src/enums/event-types.enum.ts
+++ b/src/enums/event-types.enum.ts
@@ -37,4 +37,7 @@ export enum OutlookEventTypes {
   // Cron job observability events
   HEALTH_CHECK_COMPLETED = 'outlook.cron.health_check.completed',
   RETRY_FAILED_SUBSCRIPTIONS_COMPLETED = 'outlook.cron.retry_failed_subscriptions.completed',
+
+  // Security events
+  WEBHOOK_REJECTED = 'outlook.webhook.rejected',
 }

--- a/src/guards/webhook-client-state.guard.spec.ts
+++ b/src/guards/webhook-client-state.guard.spec.ts
@@ -1,0 +1,169 @@
+import { ExecutionContext } from "@nestjs/common";
+import { EventEmitter2 } from "@nestjs/event-emitter";
+import {
+  WebhookClientStateGuard,
+  RequestWithWebhookValidation,
+  WebhookRejectedEvent,
+} from "./webhook-client-state.guard";
+import { OutlookWebhookSubscriptionRepository } from "../repositories/outlook-webhook-subscription.repository";
+import { OutlookEventTypes } from "../enums/event-types.enum";
+
+type FakeRequest = Partial<RequestWithWebhookValidation> & {
+  query?: Record<string, unknown>;
+  body?: unknown;
+  path?: string;
+};
+
+function makeContext(request: FakeRequest): ExecutionContext {
+  return {
+    switchToHttp: () => ({ getRequest: () => request }),
+  } as unknown as ExecutionContext;
+}
+
+describe("WebhookClientStateGuard", () => {
+  let guard: WebhookClientStateGuard;
+  let repo: { findBySubscriptionId: jest.Mock };
+  let emitter: { emit: jest.Mock };
+
+  beforeEach(() => {
+    repo = { findBySubscriptionId: jest.fn() };
+    emitter = { emit: jest.fn() };
+    guard = new WebhookClientStateGuard(
+      repo as unknown as OutlookWebhookSubscriptionRepository,
+      emitter as unknown as EventEmitter2,
+    );
+  });
+
+  function emittedRejections(): WebhookRejectedEvent[] {
+    return emitter.emit.mock.calls
+      .filter(([type]) => type === OutlookEventTypes.WEBHOOK_REJECTED)
+      .map(([, payload]) => payload as WebhookRejectedEvent);
+  }
+
+  it("allows validation requests through without touching the repo or emitting", async () => {
+    const req: FakeRequest = { query: { validationToken: "abc" }, body: {} };
+
+    await expect(guard.canActivate(makeContext(req))).resolves.toBe(true);
+    expect(repo.findBySubscriptionId).not.toHaveBeenCalled();
+    expect(emitter.emit).not.toHaveBeenCalled();
+  });
+
+  it("allows an empty notification body through", async () => {
+    const req: FakeRequest = { query: {}, body: { value: [] } };
+
+    await expect(guard.canActivate(makeContext(req))).resolves.toBe(true);
+    expect(emitter.emit).not.toHaveBeenCalled();
+  });
+
+  it("marks a valid clientState as valid and emits nothing", async () => {
+    repo.findBySubscriptionId.mockResolvedValue({
+      subscriptionId: "sub-1",
+      clientState: "secret-state",
+      userId: 42,
+    });
+    const req: FakeRequest = {
+      query: {},
+      path: "/calendar/webhook/notification",
+      body: { value: [{ subscriptionId: "sub-1", clientState: "secret-state" }] },
+    };
+
+    await expect(guard.canActivate(makeContext(req))).resolves.toBe(true);
+    expect(req.webhookValidation).toEqual({ valid: true, invalidItems: [] });
+    expect(emittedRejections()).toHaveLength(0);
+  });
+
+  it("rejects (and emits) a missing subscriptionId", async () => {
+    const req: FakeRequest = {
+      query: {},
+      path: "/calendar/webhook/notification",
+      body: { value: [{ clientState: "whatever" }] },
+    };
+
+    await expect(guard.canActivate(makeContext(req))).resolves.toBe(true);
+    expect(req.webhookValidation?.valid).toBe(false);
+    expect(req.webhookValidation?.invalidItems[0]).toMatchObject({
+      index: 0,
+      reason: "missing_subscription_id",
+    });
+    const events = emittedRejections();
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      reason: "missing_subscription_id",
+      subscriptionId: "unknown",
+      userId: null,
+      endpoint: "/calendar/webhook/notification",
+    });
+  });
+
+  it("rejects (and emits) an unknown subscription", async () => {
+    repo.findBySubscriptionId.mockResolvedValue(null);
+    const req: FakeRequest = {
+      query: {},
+      path: "/calendar/webhook/notification",
+      body: { value: [{ subscriptionId: "forged", clientState: "x" }] },
+    };
+
+    await expect(guard.canActivate(makeContext(req))).resolves.toBe(true);
+    expect(req.webhookValidation?.valid).toBe(false);
+    const events = emittedRejections();
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      reason: "unknown_subscription",
+      subscriptionId: "forged",
+      userId: null,
+    });
+  });
+
+  it("rejects (and emits) a clientState mismatch", async () => {
+    repo.findBySubscriptionId.mockResolvedValue({
+      subscriptionId: "sub-1",
+      clientState: "secret-state",
+      userId: 42,
+    });
+    const req: FakeRequest = {
+      query: {},
+      path: "/calendar/webhook/notification",
+      body: { value: [{ subscriptionId: "sub-1", clientState: "wrong-state" }] },
+    };
+
+    await expect(guard.canActivate(makeContext(req))).resolves.toBe(true);
+    expect(req.webhookValidation?.valid).toBe(false);
+    const events = emittedRejections();
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      reason: "client_state_mismatch",
+      subscriptionId: "sub-1",
+      userId: 42,
+    });
+  });
+
+  it("isolates a forged item in a mixed batch (one valid, one mismatch)", async () => {
+    repo.findBySubscriptionId.mockImplementation((id: string) =>
+      Promise.resolve(
+        id === "legit"
+          ? { subscriptionId: "legit", clientState: "ok", userId: 7 }
+          : { subscriptionId: "forged", clientState: "real", userId: 9 },
+      ),
+    );
+    const req: FakeRequest = {
+      query: {},
+      path: "/calendar/webhook/notification",
+      body: {
+        value: [
+          { subscriptionId: "legit", clientState: "ok" },
+          { subscriptionId: "forged", clientState: "tampered" },
+        ],
+      },
+    };
+
+    await guard.canActivate(makeContext(req));
+
+    expect(req.webhookValidation?.valid).toBe(false);
+    expect(req.webhookValidation?.invalidItems).toHaveLength(1);
+    expect(req.webhookValidation?.invalidItems[0]).toMatchObject({
+      index: 1,
+      reason: "client_state_mismatch",
+    });
+    expect(emittedRejections()).toHaveLength(1);
+  });
+});

--- a/src/guards/webhook-client-state.guard.spec.ts
+++ b/src/guards/webhook-client-state.guard.spec.ts
@@ -137,6 +137,35 @@ describe("WebhookClientStateGuard", () => {
     });
   });
 
+  it("rejects (and emits) a subscription with an empty stored clientState (fail closed)", async () => {
+    repo.findBySubscriptionId.mockResolvedValue({
+      subscriptionId: "sub-1",
+      clientState: "",
+      userId: 42,
+    });
+    const req: FakeRequest = {
+      query: {},
+      path: "/calendar/webhook/notification",
+      body: { value: [{ subscriptionId: "sub-1", clientState: "anything" }] },
+    };
+
+    await expect(guard.canActivate(makeContext(req))).resolves.toBe(true);
+    expect(req.webhookValidation?.valid).toBe(false);
+    expect(req.webhookValidation?.invalidItems[0]).toMatchObject({
+      index: 0,
+      reason: "missing_stored_client_state",
+      subscriptionId: "sub-1",
+      userId: 42,
+    });
+    const events = emittedRejections();
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      reason: "missing_stored_client_state",
+      subscriptionId: "sub-1",
+      userId: 42,
+    });
+  });
+
   it("isolates a forged item in a mixed batch (one valid, one mismatch)", async () => {
     repo.findBySubscriptionId.mockImplementation((id: string) =>
       Promise.resolve(

--- a/src/guards/webhook-client-state.guard.ts
+++ b/src/guards/webhook-client-state.guard.ts
@@ -13,6 +13,7 @@ import { OutlookEventTypes } from '../enums/event-types.enum';
 export type WebhookRejectionReason =
   | 'missing_subscription_id'
   | 'unknown_subscription'
+  | 'missing_stored_client_state'
   | 'client_state_mismatch';
 
 /** Per-item validation outcome attached to the request by {@link WebhookClientStateGuard}. */
@@ -49,8 +50,10 @@ export interface WebhookRejectedEvent {
  * Security behavior:
  * - Validation requests (with validationToken query param) are allowed through
  * - For notifications, each item's clientState is validated against stored value
- * - Mismatched clientState returns 200 (to stop Microsoft retries) but the controller
- *   skips processing invalid items (it reads `request.webhookValidation`)
+ * - A subscription with no stored clientState is unverifiable and fails closed
+ *   (rejected, not skipped)
+ * - Mismatched/unverifiable clientState returns 200 (to stop Microsoft retries) but
+ *   the controller skips processing invalid items (it reads `request.webhookValidation`)
  * - Each rejected item is logged as a security event AND emitted on
  *   {@link OutlookEventTypes.WEBHOOK_REJECTED} for observability
  *
@@ -111,8 +114,25 @@ export class WebhookClientStateGuard implements CanActivate {
           return { index, valid: false, reason: 'unknown_subscription', subscriptionId, userId: null };
         }
 
+        // A stored subscription with no clientState is unverifiable. Fail closed
+        // rather than skip the check — an empty stored value must never accept a
+        // notification (see persistence: clientState is always minted non-empty).
+        if (!subscription.clientState) {
+          this.logger.warn(
+            `[SECURITY] Subscription ${subscriptionId} has no stored clientState; ` +
+            `notification cannot be verified. Rejecting as unverifiable.`
+          );
+          return {
+            index,
+            valid: false,
+            reason: 'missing_stored_client_state',
+            subscriptionId,
+            userId: subscription.userId,
+          };
+        }
+
         // Validate clientState
-        if (subscription.clientState && clientState !== subscription.clientState) {
+        if (clientState !== subscription.clientState) {
           this.logger.warn(
             `[SECURITY] ClientState mismatch for subscription ${subscriptionId}. ` +
             `Expected prefix: user_${subscription.userId}_*, received: ${clientState?.substring(0, 20) ?? 'null'}...`

--- a/src/guards/webhook-client-state.guard.ts
+++ b/src/guards/webhook-client-state.guard.ts
@@ -4,8 +4,44 @@ import {
   ExecutionContext,
   Logger,
 } from '@nestjs/common';
+import { EventEmitter2 } from '@nestjs/event-emitter';
 import { Request } from 'express';
 import { OutlookWebhookSubscriptionRepository } from '../repositories/outlook-webhook-subscription.repository';
+import { OutlookEventTypes } from '../enums/event-types.enum';
+
+/** Reasons a webhook notification item can fail the clientState security check. */
+export type WebhookRejectionReason =
+  | 'missing_subscription_id'
+  | 'unknown_subscription'
+  | 'client_state_mismatch';
+
+/** Per-item validation outcome attached to the request by {@link WebhookClientStateGuard}. */
+export interface WebhookValidationItem {
+  index: number;
+  valid: boolean;
+  reason?: WebhookRejectionReason;
+  subscriptionId?: string;
+  userId?: number | null;
+}
+
+/** Aggregate validation result attached to the request by {@link WebhookClientStateGuard}. */
+export interface WebhookValidationResult {
+  valid: boolean;
+  invalidItems: WebhookValidationItem[];
+}
+
+/** Express request augmented with the guard's verdict for controllers to honor. */
+export type RequestWithWebhookValidation = Request & {
+  webhookValidation?: WebhookValidationResult;
+};
+
+/** Payload emitted on {@link OutlookEventTypes.WEBHOOK_REJECTED}. */
+export interface WebhookRejectedEvent {
+  subscriptionId: string;
+  userId: number | null;
+  reason: WebhookRejectionReason;
+  endpoint: string;
+}
 
 /**
  * Guard that validates clientState in Microsoft Graph webhook notifications.
@@ -13,8 +49,10 @@ import { OutlookWebhookSubscriptionRepository } from '../repositories/outlook-we
  * Security behavior:
  * - Validation requests (with validationToken query param) are allowed through
  * - For notifications, each item's clientState is validated against stored value
- * - Mismatched clientState returns 200 (to stop Microsoft retries) but rejects processing
- * - Unknown subscriptions are logged as security events
+ * - Mismatched clientState returns 200 (to stop Microsoft retries) but the controller
+ *   skips processing invalid items (it reads `request.webhookValidation`)
+ * - Each rejected item is logged as a security event AND emitted on
+ *   {@link OutlookEventTypes.WEBHOOK_REJECTED} for observability
  *
  * @see https://learn.microsoft.com/en-us/graph/change-notifications-delivery-webhooks
  */
@@ -24,10 +62,11 @@ export class WebhookClientStateGuard implements CanActivate {
 
   constructor(
     private readonly webhookSubscriptionRepository: OutlookWebhookSubscriptionRepository,
+    private readonly eventEmitter: EventEmitter2,
   ) {}
 
   async canActivate(context: ExecutionContext): Promise<boolean> {
-    const request = context.switchToHttp().getRequest<Request>();
+    const request = context.switchToHttp().getRequest<RequestWithWebhookValidation>();
 
     // Allow validation requests through (Microsoft endpoint verification)
     const validationToken = request.query.validationToken;
@@ -45,16 +84,18 @@ export class WebhookClientStateGuard implements CanActivate {
       return true;
     }
 
+    const endpoint = request.path;
+
     // Validate each notification item's clientState
-    const validationResults = await Promise.all(
-      body.value.map(async (item, index) => {
+    const validationResults: WebhookValidationItem[] = await Promise.all(
+      body.value.map(async (item, index): Promise<WebhookValidationItem> => {
         const { subscriptionId, clientState } = item;
 
         if (!subscriptionId) {
           this.logger.warn(
             `[SECURITY] Notification item ${index} missing subscriptionId`
           );
-          return { index, valid: false, reason: 'missing_subscription_id' };
+          return { index, valid: false, reason: 'missing_subscription_id', userId: null };
         }
 
         // Look up stored subscription
@@ -67,7 +108,7 @@ export class WebhookClientStateGuard implements CanActivate {
             `[SECURITY] Unknown subscription ID: ${subscriptionId}. ` +
             `Possible replay attack or stale subscription.`
           );
-          return { index, valid: false, reason: 'unknown_subscription' };
+          return { index, valid: false, reason: 'unknown_subscription', subscriptionId, userId: null };
         }
 
         // Validate clientState
@@ -76,10 +117,16 @@ export class WebhookClientStateGuard implements CanActivate {
             `[SECURITY] ClientState mismatch for subscription ${subscriptionId}. ` +
             `Expected prefix: user_${subscription.userId}_*, received: ${clientState?.substring(0, 20) ?? 'null'}...`
           );
-          return { index, valid: false, reason: 'client_state_mismatch' };
+          return {
+            index,
+            valid: false,
+            reason: 'client_state_mismatch',
+            subscriptionId,
+            userId: subscription.userId,
+          };
         }
 
-        return { index, valid: true };
+        return { index, valid: true, subscriptionId, userId: subscription.userId };
       })
     );
 
@@ -89,24 +136,28 @@ export class WebhookClientStateGuard implements CanActivate {
     if (invalidItems.length > 0) {
       this.logger.warn(
         `[SECURITY] Rejecting webhook: ${invalidItems.length}/${body.value.length} items failed validation. ` +
-        `Reasons: ${invalidItems.map((i) => `item[${i.index}]:${i.reason}`).join(', ')}`
+        `Reasons: ${invalidItems.map((i) => `item[${i.index}]:${i.reason ?? 'unknown'}`).join(', ')}`
       );
 
-      // Attach validation results to request for controller to handle
-      (request as Request & { webhookValidation: { valid: boolean; invalidItems: typeof invalidItems } }).webhookValidation = {
-        valid: false,
-        invalidItems,
-      };
+      // Emit one observability event per rejected item
+      for (const item of invalidItems) {
+        const payload: WebhookRejectedEvent = {
+          subscriptionId: item.subscriptionId ?? 'unknown',
+          userId: item.userId ?? null,
+          reason: item.reason ?? 'unknown_subscription',
+          endpoint,
+        };
+        this.eventEmitter.emit(OutlookEventTypes.WEBHOOK_REJECTED, payload);
+      }
 
-      // Return true but mark as invalid - controller should return 200 but not process
-      // This stops Microsoft from retrying invalid notifications
+      // Attach verdict to the request; the controller returns 200 but skips invalid items.
+      // Returning 200 (rather than 403) stops Microsoft from retrying forged notifications.
+      request.webhookValidation = { valid: false, invalidItems };
       return true;
     }
 
     // All items valid
-    (request as Request & { webhookValidation: { valid: boolean } }).webhookValidation = {
-      valid: true,
-    };
+    request.webhookValidation = { valid: true, invalidItems: [] };
 
     this.logger.debug(
       `ClientState validated for ${body.value.length} notification item(s)`

--- a/src/mock/graph-axios.ts
+++ b/src/mock/graph-axios.ts
@@ -1,0 +1,3 @@
+import axios from 'axios';
+
+export const graphAxios = axios.create();

--- a/src/mock/index.ts
+++ b/src/mock/index.ts
@@ -1,0 +1,5 @@
+export * from './interfaces';
+export * from './scenario-registry';
+export * from './mock-graph-interceptor.service';
+export * from './graph-axios';
+export * from './scenarios';

--- a/src/mock/interfaces.ts
+++ b/src/mock/interfaces.ts
@@ -1,0 +1,26 @@
+export interface MockRequest {
+  method: string;
+  url: string;
+  headers: Record<string, string>;
+  body?: unknown;
+}
+
+export interface MockResponse {
+  status: number;
+  data: unknown;
+  headers?: Record<string, string>;
+  delayMs?: number;
+}
+
+export interface MockRoute {
+  method: 'GET' | 'POST' | 'PATCH' | 'DELETE';
+  urlPattern: string | RegExp;
+  handler: (request: MockRequest) => MockResponse | Promise<MockResponse>;
+}
+
+export interface MockScenario {
+  name: string;
+  description: string;
+  routes: MockRoute[];
+}
+

--- a/src/mock/mock-graph-interceptor.service.ts
+++ b/src/mock/mock-graph-interceptor.service.ts
@@ -1,0 +1,203 @@
+import { Injectable, Logger, Inject, OnModuleInit } from '@nestjs/common';
+import { AxiosResponse, InternalAxiosRequestConfig } from 'axios';
+import { Client } from '@microsoft/microsoft-graph-client';
+import type { Middleware } from '@microsoft/microsoft-graph-client';
+import { MICROSOFT_CONFIG } from '../constants';
+import { MicrosoftOutlookConfig } from '../interfaces/config/outlook-config.interface';
+import { graphAxios } from './graph-axios';
+import { ScenarioRegistry } from './scenario-registry';
+import { MockRequest, MockResponse, MockRoute, MockScenario } from './interfaces';
+
+// Import built-in scenarios (triggers auto-registration)
+import './scenarios';
+
+@Injectable()
+export class MockGraphInterceptorService implements OnModuleInit {
+  private readonly logger = new Logger(MockGraphInterceptorService.name);
+  private scenario: MockScenario | undefined;
+  private interceptorId: number | undefined;
+
+  constructor(
+    @Inject(MICROSOFT_CONFIG)
+    private readonly config: MicrosoftOutlookConfig,
+  ) {}
+
+  onModuleInit(): void {
+    if (!this.isEnabled()) return;
+
+    const scenarioName = this.config.mock!.scenario;
+    this.scenario = ScenarioRegistry.get(scenarioName);
+
+    if (!this.scenario) {
+      const available = ScenarioRegistry.list().join(', ');
+      throw new Error(
+        `Mock scenario "${scenarioName}" not found. Available: ${available}`,
+      );
+    }
+
+    this.installAxiosInterceptor();
+    this.logger.log(`Mock mode enabled with scenario: "${scenarioName}"`);
+  }
+
+  isEnabled(): boolean {
+    return !!this.config.mock?.enabled;
+  }
+
+  /**
+   * Creates a Graph Client that routes requests through the mock resolver
+   * instead of making real HTTP calls.
+   */
+  createMockClient(): Client {
+    const self = this;
+
+    const mockMiddleware: Middleware = {
+      execute: async (context) => {
+        const url = context.request as string;
+        const method = (context.options?.method || 'GET').toUpperCase();
+        const body = context.options?.body
+          ? JSON.parse(context.options.body as string)
+          : undefined;
+
+        const mockRequest: MockRequest = {
+          method,
+          url: url.startsWith('https://')
+            ? url
+            : `https://graph.microsoft.com/v1.0${url.startsWith('/') ? '' : '/'}${url}`,
+          headers: {},
+          body,
+        };
+
+        const mockResponse = await self.resolveResponse(mockRequest);
+
+        if (mockResponse.delayMs) {
+          await new Promise((r) => setTimeout(r, mockResponse.delayMs));
+        }
+
+        // Simulate error for non-2xx
+        if (mockResponse.status >= 400) {
+          const error = new Error(
+            `Mock Graph API error: ${mockResponse.status}`,
+          ) as Error & { statusCode: number; code: string; body: string };
+          error.statusCode = mockResponse.status;
+          const data = mockResponse.data as Record<string, unknown> | null;
+          const errObj = data?.['error'] as Record<string, unknown> | undefined;
+          error.code = (errObj?.['code'] as string) || 'MockError';
+          error.body = JSON.stringify(mockResponse.data);
+          throw error;
+        }
+
+        context.response = new Response(JSON.stringify(mockResponse.data), {
+          status: mockResponse.status,
+          headers: {
+            'Content-Type': 'application/json',
+            ...mockResponse.headers,
+          },
+        });
+      },
+    };
+
+    return Client.initWithMiddleware({
+      authProvider: {
+        getAccessToken: async () => 'mock-access-token',
+      },
+      middleware: mockMiddleware,
+    });
+  }
+
+  async resolveResponse(request: MockRequest): Promise<MockResponse> {
+    if (!this.scenario) {
+      return { status: 200, data: {} };
+    }
+
+    const matchedRoute = this.findMatchingRoute(
+      request,
+      this.scenario.routes,
+    );
+
+    if (!matchedRoute) {
+      this.logger.warn(
+        `No mock route matched: ${request.method} ${request.url}. Returning default 200.`,
+      );
+      return { status: 200, data: {} };
+    }
+
+    return matchedRoute.handler(request);
+  }
+
+  private findMatchingRoute(
+    request: MockRequest,
+    routes: MockRoute[],
+  ): MockRoute | undefined {
+    return routes.find((route) => {
+      if (route.method !== request.method) return false;
+
+      if (typeof route.urlPattern === 'string') {
+        return request.url.includes(route.urlPattern);
+      }
+      return route.urlPattern.test(request.url);
+    });
+  }
+
+  private installAxiosInterceptor(): void {
+    this.interceptorId = graphAxios.interceptors.request.use(
+      async (config: InternalAxiosRequestConfig) => {
+        if (!this.isGraphUrl(config.url)) return config;
+
+        const method = (config.method || 'GET').toUpperCase();
+        const mockRequest: MockRequest = {
+          method,
+          url: config.url!,
+          headers: config.headers
+            ? Object.fromEntries(
+                Object.entries(config.headers).map(([k, v]) => [
+                  k,
+                  String(v),
+                ]),
+              )
+            : {},
+          body: config.data,
+        };
+
+        const mockResponse = await this.resolveResponse(mockRequest);
+
+        if (mockResponse.delayMs) {
+          await new Promise((r) => setTimeout(r, mockResponse.delayMs));
+        }
+
+        // Use custom adapter to short-circuit the real HTTP call
+        config.adapter = async (): Promise<AxiosResponse> => {
+          const response: AxiosResponse = {
+            data: mockResponse.data,
+            status: mockResponse.status,
+            statusText: mockResponse.status < 400 ? 'OK' : 'Mock Error',
+            headers: mockResponse.headers || {},
+            config,
+          };
+
+          // Axios treats non-2xx as errors by default
+          if (mockResponse.status >= 400) {
+            const error = new Error(
+              `Request failed with status code ${mockResponse.status}`,
+            ) as Error & { response: AxiosResponse; config: InternalAxiosRequestConfig; isAxiosError: boolean };
+            error.response = response;
+            error.config = config;
+            error.isAxiosError = true;
+            throw error;
+          }
+
+          return response;
+        };
+
+        return config;
+      },
+    );
+  }
+
+  private isGraphUrl(url?: string): boolean {
+    if (!url) return false;
+    return (
+      url.includes('graph.microsoft.com') ||
+      url.includes('login.microsoftonline.com')
+    );
+  }
+}

--- a/src/mock/scenario-registry.ts
+++ b/src/mock/scenario-registry.ts
@@ -1,0 +1,21 @@
+import { MockScenario } from './interfaces';
+
+export class ScenarioRegistry {
+  private static scenarios = new Map<string, MockScenario>();
+
+  static register(scenario: MockScenario): void {
+    ScenarioRegistry.scenarios.set(scenario.name, scenario);
+  }
+
+  static get(name: string): MockScenario | undefined {
+    return ScenarioRegistry.scenarios.get(name);
+  }
+
+  static list(): string[] {
+    return Array.from(ScenarioRegistry.scenarios.keys());
+  }
+
+  static has(name: string): boolean {
+    return ScenarioRegistry.scenarios.has(name);
+  }
+}

--- a/src/mock/scenarios/batch-partial-failure.scenario.ts
+++ b/src/mock/scenarios/batch-partial-failure.scenario.ts
@@ -1,0 +1,121 @@
+import { MockScenario, MockResponse, MockRequest } from '../interfaces';
+
+export const batchPartialFailureScenario: MockScenario = {
+  name: 'batch-partial-failure',
+  description: 'Batch operations return mixed results: odd-indexed requests fail with 409 Conflict',
+  routes: [
+    // Token endpoint
+    {
+      method: 'POST',
+      urlPattern: 'login.microsoftonline.com',
+      handler: (): MockResponse => ({
+        status: 200,
+        data: {
+          access_token: 'mock-access-token',
+          refresh_token: 'mock-refresh-token',
+          expires_in: 3600,
+          token_type: 'Bearer',
+        },
+      }),
+    },
+    // Mailbox validation
+    {
+      method: 'GET',
+      urlPattern: '/me/mailboxSettings',
+      handler: (): MockResponse => ({
+        status: 200,
+        data: { timeZone: 'UTC' },
+      }),
+    },
+    // Default calendar
+    {
+      method: 'GET',
+      urlPattern: /\/me\/calendar$/,
+      handler: (): MockResponse => ({
+        status: 200,
+        data: { id: 'mock-calendar-id', name: 'Calendar' },
+      }),
+    },
+    // Batch operations — alternate success/failure
+    {
+      method: 'POST',
+      urlPattern: '$batch',
+      handler: (req: MockRequest): MockResponse => {
+        const body = req.body as {
+          requests: Array<{ id: string; method: string; url: string; body?: unknown }>;
+        };
+        const now = new Date().toISOString();
+        const responses = (body.requests || []).map((r, index) => {
+          if (index % 2 === 1) {
+            // Odd-indexed items fail
+            return {
+              id: r.id,
+              status: 409,
+              body: {
+                error: {
+                  code: 'Conflict',
+                  message: 'The resource has been modified by another process.',
+                },
+              },
+            };
+          }
+          const isDelete = r.method === 'DELETE';
+          const isCreate = r.method === 'POST';
+          return {
+            id: r.id,
+            status: isDelete ? 204 : isCreate ? 201 : 200,
+            body: isDelete
+              ? null
+              : {
+                  id: `mock-event-batch-${r.id}`,
+                  iCalUId: `ical-batch-${r.id}`,
+                  subject: 'Batch Event',
+                  createdDateTime: now,
+                  lastModifiedDateTime: now,
+                  ...(r.body as Record<string, unknown> || {}),
+                },
+          };
+        });
+        return { status: 200, data: { responses } };
+      },
+    },
+    // Single event operations work normally
+    {
+      method: 'POST',
+      urlPattern: /\/calendars\/[^/]+\/events$/,
+      handler: (req: MockRequest): MockResponse => {
+        const now = new Date().toISOString();
+        return {
+          status: 201,
+          data: {
+            id: `mock-event-${Date.now()}`,
+            iCalUId: `ical-${Date.now()}`,
+            createdDateTime: now,
+            lastModifiedDateTime: now,
+            ...(req.body as Record<string, unknown>),
+          },
+        };
+      },
+    },
+    // Subscriptions work normally
+    {
+      method: 'GET',
+      urlPattern: '/subscriptions',
+      handler: (): MockResponse => ({
+        status: 200,
+        data: { value: [] },
+      }),
+    },
+    {
+      method: 'POST',
+      urlPattern: '/subscriptions',
+      handler: (): MockResponse => ({
+        status: 201,
+        data: {
+          id: `mock-sub-${Date.now()}`,
+          expirationDateTime: new Date(Date.now() + 72 * 3600000).toISOString(),
+        },
+      }),
+    },
+  ],
+};

--- a/src/mock/scenarios/empty-calendar.scenario.ts
+++ b/src/mock/scenarios/empty-calendar.scenario.ts
@@ -1,0 +1,102 @@
+import { MockScenario, MockResponse, MockRequest } from '../interfaces';
+
+export const emptyCalendarScenario: MockScenario = {
+  name: 'empty-calendar',
+  description: 'User has a valid mailbox but zero events, no subscriptions, empty delta',
+  routes: [
+    // Token endpoint
+    {
+      method: 'POST',
+      urlPattern: 'login.microsoftonline.com',
+      handler: (): MockResponse => ({
+        status: 200,
+        data: {
+          access_token: 'mock-access-token',
+          refresh_token: 'mock-refresh-token',
+          expires_in: 3600,
+          token_type: 'Bearer',
+        },
+      }),
+    },
+    // Mailbox validation
+    {
+      method: 'GET',
+      urlPattern: '/me/mailboxSettings',
+      handler: (): MockResponse => ({
+        status: 200,
+        data: { timeZone: 'UTC' },
+      }),
+    },
+    // Default calendar
+    {
+      method: 'GET',
+      urlPattern: /\/me\/calendar$/,
+      handler: (): MockResponse => ({
+        status: 200,
+        data: {
+          id: 'mock-empty-calendar-id',
+          name: 'Calendar',
+          isDefaultCalendar: true,
+        },
+      }),
+    },
+    // Calendar view — empty
+    {
+      method: 'GET',
+      urlPattern: '/calendarView',
+      handler: (): MockResponse => ({
+        status: 200,
+        data: { value: [] },
+      }),
+    },
+    // Delta sync — no changes
+    {
+      method: 'GET',
+      urlPattern: '/events/delta',
+      handler: (): MockResponse => ({
+        status: 200,
+        data: {
+          value: [],
+          '@odata.deltaLink': 'https://graph.microsoft.com/v1.0/me/events/delta?$deltatoken=empty-token',
+        },
+      }),
+    },
+    // List subscriptions — none
+    {
+      method: 'GET',
+      urlPattern: '/subscriptions',
+      handler: (): MockResponse => ({
+        status: 200,
+        data: { value: [] },
+      }),
+    },
+    // Create subscription — succeeds
+    {
+      method: 'POST',
+      urlPattern: '/subscriptions',
+      handler: (req: MockRequest): MockResponse => {
+        const body = req.body as Record<string, unknown>;
+        return {
+          status: 201,
+          data: {
+            id: `mock-sub-empty-${Date.now()}`,
+            resource: body.resource,
+            changeType: body.changeType,
+            clientState: body.clientState,
+            notificationUrl: body.notificationUrl,
+            expirationDateTime: body.expirationDateTime,
+          },
+        };
+      },
+    },
+    // Delete subscription
+    {
+      method: 'DELETE',
+      urlPattern: /\/subscriptions\//,
+      handler: (): MockResponse => ({
+        status: 204,
+        data: null,
+      }),
+    },
+  ],
+};

--- a/src/mock/scenarios/happy-path.scenario.ts
+++ b/src/mock/scenarios/happy-path.scenario.ts
@@ -1,0 +1,280 @@
+import { MockScenario, MockRequest, MockResponse } from '../interfaces';
+
+let eventCounter = 0;
+let subscriptionCounter = 0;
+
+function mockEventId(): string {
+  return `mock-event-${++eventCounter}-${Date.now()}`;
+}
+
+function mockSubscriptionId(): string {
+  return `mock-sub-${++subscriptionCounter}-${Date.now()}`;
+}
+
+function buildEvent(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  const now = new Date().toISOString();
+  const id = mockEventId();
+  return {
+    id,
+    iCalUId: `ical-${id}`,
+    subject: 'Mock Event',
+    bodyPreview: 'This is a mock event',
+    body: { contentType: 'html', content: '<p>Mock event body</p>' },
+    start: { dateTime: now, timeZone: 'UTC' },
+    end: { dateTime: new Date(Date.now() + 3600000).toISOString(), timeZone: 'UTC' },
+    location: { displayName: 'Mock Location' },
+    attendees: [],
+    organizer: {
+      emailAddress: { name: 'Mock User', address: 'mock@example.com' },
+    },
+    isAllDay: false,
+    isCancelled: false,
+    showAs: 'busy',
+    sensitivity: 'normal',
+    createdDateTime: now,
+    lastModifiedDateTime: now,
+    changeKey: `ck-${id}`,
+    ...overrides,
+  };
+}
+
+export const happyPathScenario: MockScenario = {
+  name: 'happy-path',
+  description: 'All API calls succeed with realistic sample data',
+  routes: [
+    // ── Token endpoints ──
+    {
+      method: 'POST',
+      urlPattern: 'login.microsoftonline.com',
+      handler: (): MockResponse => ({
+        status: 200,
+        data: {
+          access_token: 'mock-access-token-' + Date.now(),
+          refresh_token: 'mock-refresh-token-' + Date.now(),
+          expires_in: 3600,
+          token_type: 'Bearer',
+          scope: 'Calendars.ReadWrite Mail.ReadWrite User.Read offline_access',
+        },
+      }),
+    },
+
+    // ── Mailbox validation ──
+    {
+      method: 'GET',
+      urlPattern: '/me/mailboxSettings',
+      handler: (): MockResponse => ({
+        status: 200,
+        data: {
+          timeZone: 'UTC',
+          dateFormat: 'MM/dd/yyyy',
+          timeFormat: 'hh:mm tt',
+          language: { locale: 'en-US' },
+        },
+      }),
+    },
+
+    // ── Default calendar ──
+    {
+      method: 'GET',
+      urlPattern: /\/me\/calendar$/,
+      handler: (): MockResponse => ({
+        status: 200,
+        data: {
+          id: 'mock-default-calendar-id',
+          name: 'Calendar',
+          color: 'auto',
+          isDefaultCalendar: true,
+          canEdit: true,
+          owner: { name: 'Mock User', address: 'mock@example.com' },
+        },
+      }),
+    },
+
+    // ── Calendar view (import / streaming) ──
+    {
+      method: 'GET',
+      urlPattern: '/calendarView',
+      handler: (): MockResponse => ({
+        status: 200,
+        data: {
+          value: [buildEvent(), buildEvent({ subject: 'Mock Event 2' })],
+          // No @odata.nextLink = last page
+        },
+      }),
+    },
+
+    // ── Delta sync ──
+    {
+      method: 'GET',
+      urlPattern: '/events/delta',
+      handler: (): MockResponse => ({
+        status: 200,
+        data: {
+          value: [buildEvent({ subject: 'Delta Change Event' })],
+          '@odata.deltaLink': 'https://graph.microsoft.com/v1.0/me/events/delta?$deltatoken=mock-delta-token',
+        },
+      }),
+    },
+
+    // ── Recurring event instances ──
+    {
+      method: 'GET',
+      urlPattern: '/instances',
+      handler: (): MockResponse => ({
+        status: 200,
+        data: {
+          value: [
+            buildEvent({ subject: 'Instance 1', type: 'occurrence' }),
+            buildEvent({ subject: 'Instance 2', type: 'occurrence' }),
+          ],
+        },
+      }),
+    },
+
+    // ── Create event ──
+    {
+      method: 'POST',
+      urlPattern: /\/calendars\/[^/]+\/events$/,
+      handler: (req: MockRequest): MockResponse => ({
+        status: 201,
+        data: buildEvent(req.body as Record<string, unknown>),
+      }),
+    },
+
+    // ── Update event ──
+    {
+      method: 'PATCH',
+      urlPattern: /\/events\//,
+      handler: (req: MockRequest): MockResponse => ({
+        status: 200,
+        data: buildEvent({
+          ...(req.body as Record<string, unknown>),
+          lastModifiedDateTime: new Date().toISOString(),
+        }),
+      }),
+    },
+
+    // ── Delete event ──
+    {
+      method: 'DELETE',
+      urlPattern: /\/events\//,
+      handler: (): MockResponse => ({
+        status: 204,
+        data: null,
+      }),
+    },
+
+    // ── Get single event ──
+    {
+      method: 'GET',
+      urlPattern: /\/events\/[^/?]+$/,
+      handler: (): MockResponse => ({
+        status: 200,
+        data: buildEvent(),
+      }),
+    },
+
+    // ── Batch operations ──
+    {
+      method: 'POST',
+      urlPattern: '$batch',
+      handler: (req: MockRequest): MockResponse => {
+        const body = req.body as { requests: Array<{ id: string; method: string; url: string; body?: unknown }> };
+        const responses = (body.requests || []).map((r) => {
+          const isCreate = r.method === 'POST';
+          const isDelete = r.method === 'DELETE';
+          return {
+            id: r.id,
+            status: isDelete ? 204 : isCreate ? 201 : 200,
+            body: isDelete ? null : buildEvent(r.body as Record<string, unknown> || {}),
+          };
+        });
+        return { status: 200, data: { responses } };
+      },
+    },
+
+    // ── Subscriptions ──
+    {
+      method: 'POST',
+      urlPattern: '/subscriptions',
+      handler: (req: MockRequest): MockResponse => {
+        const body = req.body as Record<string, unknown>;
+        const subId = mockSubscriptionId();
+        return {
+          status: 201,
+          data: {
+            id: subId,
+            resource: body.resource || '/me/events',
+            changeType: body.changeType || 'created,updated,deleted',
+            clientState: body.clientState,
+            notificationUrl: body.notificationUrl,
+            expirationDateTime: body.expirationDateTime || new Date(Date.now() + 72 * 3600000).toISOString(),
+          },
+        };
+      },
+    },
+
+    {
+      method: 'GET',
+      urlPattern: '/subscriptions',
+      handler: (): MockResponse => ({
+        status: 200,
+        data: {
+          value: [],
+        },
+      }),
+    },
+
+    {
+      method: 'PATCH',
+      urlPattern: /\/subscriptions\//,
+      handler: (req: MockRequest): MockResponse => {
+        const body = req.body as Record<string, unknown>;
+        return {
+          status: 200,
+          data: {
+            id: 'mock-sub-renewed',
+            expirationDateTime: body.expirationDateTime || new Date(Date.now() + 72 * 3600000).toISOString(),
+          },
+        };
+      },
+    },
+
+    {
+      method: 'DELETE',
+      urlPattern: /\/subscriptions\//,
+      handler: (): MockResponse => ({
+        status: 204,
+        data: null,
+      }),
+    },
+
+    // ── Send email ──
+    {
+      method: 'POST',
+      urlPattern: '/me/sendMail',
+      handler: (): MockResponse => ({
+        status: 202,
+        data: null,
+      }),
+    },
+
+    // ── Get email message ──
+    {
+      method: 'GET',
+      urlPattern: /\/me\/messages\//,
+      handler: (): MockResponse => ({
+        status: 200,
+        data: {
+          id: 'mock-message-id',
+          subject: 'Mock Email',
+          body: { contentType: 'html', content: '<p>Mock email body</p>' },
+          from: { emailAddress: { name: 'Sender', address: 'sender@example.com' } },
+          toRecipients: [{ emailAddress: { name: 'Recipient', address: 'recipient@example.com' } }],
+          receivedDateTime: new Date().toISOString(),
+          isRead: false,
+        },
+      }),
+    },
+  ],
+};

--- a/src/mock/scenarios/index.ts
+++ b/src/mock/scenarios/index.ts
@@ -1,0 +1,24 @@
+import { ScenarioRegistry } from '../scenario-registry';
+import { happyPathScenario } from './happy-path.scenario';
+import { tokenExpiredScenario } from './token-expired.scenario';
+import { rateLimitedScenario } from './rate-limited.scenario';
+import { mailboxInactiveScenario } from './mailbox-inactive.scenario';
+import { emptyCalendarScenario } from './empty-calendar.scenario';
+import { batchPartialFailureScenario } from './batch-partial-failure.scenario';
+
+// Auto-register all built-in scenarios
+ScenarioRegistry.register(happyPathScenario);
+ScenarioRegistry.register(tokenExpiredScenario);
+ScenarioRegistry.register(rateLimitedScenario);
+ScenarioRegistry.register(mailboxInactiveScenario);
+ScenarioRegistry.register(emptyCalendarScenario);
+ScenarioRegistry.register(batchPartialFailureScenario);
+
+export {
+  happyPathScenario,
+  tokenExpiredScenario,
+  rateLimitedScenario,
+  mailboxInactiveScenario,
+  emptyCalendarScenario,
+  batchPartialFailureScenario,
+};

--- a/src/mock/scenarios/mailbox-inactive.scenario.ts
+++ b/src/mock/scenarios/mailbox-inactive.scenario.ts
@@ -1,0 +1,68 @@
+import { MockScenario, MockResponse } from '../interfaces';
+
+export const mailboxInactiveScenario: MockScenario = {
+  name: 'mailbox-inactive',
+  description: 'Mailbox validation fails with MailboxNotEnabledForRESTAPI error (on-prem, soft-deleted, or inactive)',
+  routes: [
+    // Token endpoint works normally
+    {
+      method: 'POST',
+      urlPattern: 'login.microsoftonline.com',
+      handler: (): MockResponse => ({
+        status: 200,
+        data: {
+          access_token: 'mock-access-token',
+          refresh_token: 'mock-refresh-token',
+          expires_in: 3600,
+          token_type: 'Bearer',
+        },
+      }),
+    },
+    // Mailbox settings check fails
+    {
+      method: 'GET',
+      urlPattern: '/me/mailboxSettings',
+      handler: (): MockResponse => ({
+        status: 403,
+        data: {
+          error: {
+            code: 'MailboxNotEnabledForRESTAPI',
+            message:
+              "REST API is not yet supported for this mailbox. This could be because the user's mailbox is on a legacy Exchange server.",
+            innerError: {
+              date: new Date().toISOString(),
+              'request-id': 'mock-request-id',
+            },
+          },
+        },
+      }),
+    },
+    // All other Graph calls also fail with same error
+    {
+      method: 'GET',
+      urlPattern: 'graph.microsoft.com',
+      handler: (): MockResponse => ({
+        status: 403,
+        data: {
+          error: {
+            code: 'MailboxNotEnabledForRESTAPI',
+            message: 'REST API is not yet supported for this mailbox.',
+          },
+        },
+      }),
+    },
+    {
+      method: 'POST',
+      urlPattern: 'graph.microsoft.com',
+      handler: (): MockResponse => ({
+        status: 403,
+        data: {
+          error: {
+            code: 'MailboxNotEnabledForRESTAPI',
+            message: 'REST API is not yet supported for this mailbox.',
+          },
+        },
+      }),
+    },
+  ],
+};

--- a/src/mock/scenarios/rate-limited.scenario.ts
+++ b/src/mock/scenarios/rate-limited.scenario.ts
@@ -1,0 +1,79 @@
+import { MockScenario, MockResponse } from '../interfaces';
+
+export const rateLimitedScenario: MockScenario = {
+  name: 'rate-limited',
+  description: 'All Graph API calls return 429 Too Many Requests with Retry-After header',
+  routes: [
+    // Token endpoint works normally
+    {
+      method: 'POST',
+      urlPattern: 'login.microsoftonline.com',
+      handler: (): MockResponse => ({
+        status: 200,
+        data: {
+          access_token: 'mock-access-token',
+          refresh_token: 'mock-refresh-token',
+          expires_in: 3600,
+          token_type: 'Bearer',
+        },
+      }),
+    },
+    // All Graph API calls get rate-limited
+    {
+      method: 'GET',
+      urlPattern: 'graph.microsoft.com',
+      handler: (): MockResponse => ({
+        status: 429,
+        data: {
+          error: {
+            code: 'TooManyRequests',
+            message: 'Too many requests. Please retry after 10 seconds.',
+          },
+        },
+        headers: { 'Retry-After': '10' },
+      }),
+    },
+    {
+      method: 'POST',
+      urlPattern: 'graph.microsoft.com',
+      handler: (): MockResponse => ({
+        status: 429,
+        data: {
+          error: {
+            code: 'TooManyRequests',
+            message: 'Too many requests. Please retry after 10 seconds.',
+          },
+        },
+        headers: { 'Retry-After': '10' },
+      }),
+    },
+    {
+      method: 'PATCH',
+      urlPattern: 'graph.microsoft.com',
+      handler: (): MockResponse => ({
+        status: 429,
+        data: {
+          error: {
+            code: 'TooManyRequests',
+            message: 'Too many requests. Please retry after 10 seconds.',
+          },
+        },
+        headers: { 'Retry-After': '10' },
+      }),
+    },
+    {
+      method: 'DELETE',
+      urlPattern: 'graph.microsoft.com',
+      handler: (): MockResponse => ({
+        status: 429,
+        data: {
+          error: {
+            code: 'TooManyRequests',
+            message: 'Too many requests. Please retry after 10 seconds.',
+          },
+        },
+        headers: { 'Retry-After': '10' },
+      }),
+    },
+  ],
+};

--- a/src/mock/scenarios/token-expired.scenario.ts
+++ b/src/mock/scenarios/token-expired.scenario.ts
@@ -1,0 +1,77 @@
+import { MockScenario, MockResponse } from '../interfaces';
+
+export const tokenExpiredScenario: MockScenario = {
+  name: 'token-expired',
+  description: 'Token refresh fails with invalid_grant, simulating expired/revoked refresh token',
+  routes: [
+    {
+      method: 'POST',
+      urlPattern: 'login.microsoftonline.com',
+      handler: (): MockResponse => ({
+        status: 400,
+        data: {
+          error: 'invalid_grant',
+          error_description:
+            'AADSTS70000: The refresh token has expired due to inactivity.',
+          error_codes: [70000],
+          timestamp: new Date().toISOString(),
+          trace_id: 'mock-trace-id',
+          correlation_id: 'mock-correlation-id',
+        },
+      }),
+    },
+    // All Graph API calls return 401 Unauthorized
+    {
+      method: 'GET',
+      urlPattern: 'graph.microsoft.com',
+      handler: (): MockResponse => ({
+        status: 401,
+        data: {
+          error: {
+            code: 'InvalidAuthenticationToken',
+            message: 'Access token has expired or is not yet valid.',
+          },
+        },
+      }),
+    },
+    {
+      method: 'POST',
+      urlPattern: 'graph.microsoft.com',
+      handler: (): MockResponse => ({
+        status: 401,
+        data: {
+          error: {
+            code: 'InvalidAuthenticationToken',
+            message: 'Access token has expired or is not yet valid.',
+          },
+        },
+      }),
+    },
+    {
+      method: 'PATCH',
+      urlPattern: 'graph.microsoft.com',
+      handler: (): MockResponse => ({
+        status: 401,
+        data: {
+          error: {
+            code: 'InvalidAuthenticationToken',
+            message: 'Access token has expired or is not yet valid.',
+          },
+        },
+      }),
+    },
+    {
+      method: 'DELETE',
+      urlPattern: 'graph.microsoft.com',
+      handler: (): MockResponse => ({
+        status: 401,
+        data: {
+          error: {
+            code: 'InvalidAuthenticationToken',
+            message: 'Access token has expired or is not yet valid.',
+          },
+        },
+      }),
+    },
+  ],
+};

--- a/src/services/calendar/calendar.service.ts
+++ b/src/services/calendar/calendar.service.ts
@@ -1855,12 +1855,14 @@ export class CalendarService {
       return { success: false, message: "Unknown subscription" };
     }
 
-    // Verify the client state for additional security
-    if (
-      subscription.clientState &&
-      clientState !== subscription.clientState
-    ) {
-      this.logger.warn("Client state mismatch");
+    // Verify the client state for additional security. A subscription with no
+    // stored clientState is unverifiable — fail closed rather than skip the check.
+    if (!subscription.clientState || clientState !== subscription.clientState) {
+      this.logger.warn(
+        subscription.clientState
+          ? "Client state mismatch"
+          : "Subscription has no stored clientState; cannot verify notification"
+      );
       return { success: false, message: "Client state mismatch" };
     }
 

--- a/src/services/email/email.service.ts
+++ b/src/services/email/email.service.ts
@@ -103,6 +103,10 @@ export class EmailService {
       // Create subscription payload with proper URL encoding
       const notificationUrl = `${basePathUrl}/email/webhook`;
 
+      // Generate the clientState we bind to this subscription. It must never be
+      // empty — an empty stored value makes notifications unverifiable downstream.
+      const clientState = `user_${internalUserId}_${randomUUID()}`;
+
       // Create subscription payload
       const subscriptionData = {
         changeType: 'created,updated,deleted',
@@ -111,7 +115,7 @@ export class EmailService {
         lifecycleNotificationUrl: notificationUrl,
         resource: '/me/messages',
         expirationDateTime: expirationDateTime.toISOString(),
-        clientState: `user_${internalUserId}_${randomUUID()}`,
+        clientState,
       };
 
       this.logger.debug(`Creating email webhook subscription with notificationUrl: ${notificationUrl}`);
@@ -144,13 +148,20 @@ export class EmailService {
 
       this.logger.log(`Created email webhook subscription ${response.data.id || 'unknown'} for user ${internalUserId}`);
 
+      // Persist the clientState we generated. Microsoft normally echoes it back;
+      // if it didn't, fall back to our own value so the stored value is never empty.
+      const storedClientState = response.data.clientState || clientState;
+      if (!storedClientState) {
+        throw new Error('Refusing to persist subscription with empty clientState');
+      }
+
       // Save the subscription to the database
       await this.webhookSubscriptionRepository.saveSubscription({
         subscriptionId: response.data.id,
         userId: internalUserId,
         resource: response.data.resource,
         changeType: response.data.changeType,
-        clientState: response.data.clientState || '',
+        clientState: storedClientState,
         notificationUrl: response.data.notificationUrl,
         expirationDateTime: response.data.expirationDateTime ? new Date(response.data.expirationDateTime) : new Date(),
       });
@@ -323,9 +334,14 @@ export class EmailService {
         return { success: false, message: 'Unknown subscription' };
       }
 
-      // Verify the client state for additional security
-      if (subscription.clientState && clientState !== subscription.clientState) {
-        this.logger.warn('Client state mismatch');
+      // Verify the client state for additional security. A subscription with no
+      // stored clientState is unverifiable — fail closed rather than skip the check.
+      if (!subscription.clientState || clientState !== subscription.clientState) {
+        this.logger.warn(
+          subscription.clientState
+            ? 'Client state mismatch'
+            : 'Subscription has no stored clientState; cannot verify notification',
+        );
         return { success: false, message: 'Client state mismatch' };
       }
 

--- a/src/services/subscription/microsoft-subscription.service.ts
+++ b/src/services/subscription/microsoft-subscription.service.ts
@@ -244,6 +244,10 @@ export class MicrosoftSubscriptionService {
       const webhookPath = this.microsoftConfig.calendarWebhookPath || '/calendar/webhook';
       const notificationUrl = `${basePathUrl}${webhookPath}`;
 
+      // Generate the clientState we bind to this subscription. It must never be
+      // empty — an empty stored value makes notifications unverifiable downstream.
+      const clientState = `user_${internalUserId}_${randomUUID()}`;
+
       // Create subscription payload
       const subscriptionData = {
         changeType: "created,updated,deleted",
@@ -252,7 +256,7 @@ export class MicrosoftSubscriptionService {
         lifecycleNotificationUrl: notificationUrl,
         resource: "/me/events",
         expirationDateTime: expirationDateTime.toISOString(),
-        clientState: `user_${internalUserId}_${randomUUID()}`,
+        clientState,
       };
 
       this.logger.log(
@@ -291,6 +295,13 @@ export class MicrosoftSubscriptionService {
         `[${correlationId}] Created webhook subscription ${response.data.id || "unknown"} for user ${internalUserId}`
       );
 
+      // Persist the clientState we generated. Microsoft normally echoes it back;
+      // if it didn't, fall back to our own value so the stored value is never empty.
+      const storedClientState = response.data.clientState || clientState;
+      if (!storedClientState) {
+        throw new Error('Refusing to persist subscription with empty clientState');
+      }
+
       // Save the subscription to the database
       this.logger.log(`[${correlationId}] Saving subscription to database (internalUserId: ${internalUserId}, externalUserId: ${externalUserId})`);
       await this.webhookSubscriptionRepository.saveSubscription({
@@ -298,7 +309,7 @@ export class MicrosoftSubscriptionService {
         userId: internalUserId,
         resource: response.data.resource,
         changeType: response.data.changeType,
-        clientState: response.data.clientState || "",
+        clientState: storedClientState,
         notificationUrl: response.data.notificationUrl,
         expirationDateTime: response.data.expirationDateTime
           ? new Date(response.data.expirationDateTime)

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,5 +20,5 @@
     "noFallthroughCasesInSwitch": true
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist", "test", "**/*.spec.ts", "**/*.test.ts"]
+  "exclude": ["node_modules", "dist", "test", "src/mock", "**/*.spec.ts", "**/*.test.ts"]
 } 


### PR DESCRIPTION
# Enforce webhook clientState security on Outlook notifications

## Summary

Microsoft Graph webhook notifications were validated for `clientState` by `WebhookClientStateGuard`, but the guard's verdict was never actually enforced — the controllers processed **all** notification items regardless of whether they passed validation. This PR closes that gap: rejected items are now dropped before processing, each rejection emits an observability event, and a mock Graph harness is added so the whole webhook/sync flow can be exercised offline.

## Motivation

A forged or replayed notification (unknown `subscriptionId`, mismatched `clientState`, or missing `subscriptionId`) would still be handed to the calendar/email sync pipeline. The guard already detected these cases and attached a `webhookValidation` verdict to the request, but no controller read it — so the security check was effectively inert.

## Changes

### Guard — `webhook-client-state.guard.ts`

- Exported strong types for the verdict: `WebhookValidationItem`, `WebhookValidationResult`, `RequestWithWebhookValidation`, `WebhookRejectionReason`, `WebhookRejectedEvent` (replacing the inline `as` casts).
- Each invalid item now carries `subscriptionId` and `userId` for traceability.
- Emits one `OutlookEventTypes.WEBHOOK_REJECTED` event per rejected item (via injected `EventEmitter2`) for observability/alerting.
- Behavior unchanged on the wire: still returns **200** on forged notifications so Microsoft stops retrying — but now the controller honors the verdict instead of ignoring it.

### Controllers — `calendar.controller.ts`, `email.controller.ts`

- New `filterAuthorizedItems()` helper drops items the guard flagged (matched by index) and reports `rejectedCount`.
- All processing paths (sync, async 202 batch, legacy `/webhook`) now operate on `authorized` items only.
- When every item fails validation, acknowledges with 200 and processes nothing.
- `processCalendarNotificationBatch` / `processEmailNotificationBatch` refactored to take a pre-filtered item array instead of the raw DTO.

### Enum — `event-types.enum.ts`

- Adds `WEBHOOK_REJECTED = 'outlook.webhook.rejected'`.

### Mock Graph harness — `src/mock/` (new)

- A config-selectable mock backend that intercepts Graph SDK + axios calls so the library can run against simulated Graph responses with no live mailbox. Activated via `config.mock.enabled` + `config.mock.scenario`.
- Six built-in scenarios: `happy-path`, `token-expired`, `rate-limited`, `mailbox-inactive`, `empty-calendar`, `batch-partial-failure`.

### Tests

- `webhook-client-state.guard.spec.ts` (new): validation pass-through, missing subscriptionId, unknown subscription, clientState mismatch, mixed-batch isolation, and emit assertions.
- `calendar.controller.spec.ts`: verifies guard-rejected items are not processed (still 200), mixed batches process only authorized items, and the legacy `/webhook` path also skips invalid items.

### Build/lint config

- `src/mock/**` excluded from ESLint (`eslint.config.mjs`) and from `tsconfig.json` build output (the mock harness is a test/dev aid, not shipped lib code).

## Behavior change

| Notification | Before | After |
| --- | --- | --- |
| Valid clientState | Processed | Processed (unchanged) |
| Forged / unknown / missing | **Processed** | **Dropped**, 200 returned, `WEBHOOK_REJECTED` emitted |
| Mixed batch | All processed | Only valid items processed |

## Test plan

- [ ] `npm test` (guard + controller specs pass)
- [ ] `npm run lint` / `npm run build` clean with new ignore rules
- [ ] Manual: forged `clientState` returns 200 and is not synced; valid notification syncs normally
- [ ] Confirm `WEBHOOK_REJECTED` events surface in observability
