### PR TITLE
fix: upgrade Node.js to 22.x and actions/checkout to v4 in npm-publish workflow

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -16,7 +16,7 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Get latest tag
@@ -29,7 +29,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20.x'
+          node-version: '22.x'
           registry-url: 'https://registry.npmjs.org'
           # OIDC will be used automatically if no NODE_AUTH_TOKEN is set
       - name: Check if tag was created in the trigger workflow


### PR DESCRIPTION
## Summary

- Upgrades `actions/checkout` from v3 to v4 in the npm-publish workflow
- Upgrades the Node.js version from `20.x` to `22.x` to match current LTS

## Test plan

- [ ] Verify the npm-publish workflow runs successfully on the next release tag
- [ ] Confirm Node.js 22.x is compatible with the build and publish steps
