### PR TITLE
fix: validate required config fields at startup with clear error mess…

### DIFF
--- a/src/services/auth/app-only-auth.service.ts
+++ b/src/services/auth/app-only-auth.service.ts
@@ -527,6 +527,20 @@ export class AppOnlyAuthService implements OnModuleInit {
   private buildAdminConsentRedirectUri(): string {
     const config = this.microsoftConfig;
 
+    if (!config.redirectPath) {
+      throw new Error(
+        'MicrosoftOutlookModule config is missing required field: redirectPath. ' +
+        'Ensure it is provided when calling MicrosoftOutlookModule.forRoot() or MicrosoftOutlookModule.forRootAsync().',
+      );
+    }
+
+    if (!config.backendBaseUrl) {
+      throw new Error(
+        'MicrosoftOutlookModule config is missing required field: backendBaseUrl. ' +
+        'Ensure it is provided when calling MicrosoftOutlookModule.forRoot() or MicrosoftOutlookModule.forRootAsync().',
+      );
+    }
+
     // If redirectPath already contains a full URL, use it directly
     if (config.redirectPath.startsWith('http')) {
       // Replace the user auth callback path with admin consent path

--- a/src/services/auth/microsoft-auth.service.ts
+++ b/src/services/auth/microsoft-auth.service.ts
@@ -93,21 +93,29 @@ export class MicrosoftAuthService {
     @Inject(OUTLOOK_LOCK_STORE)
     private readonly lockStore: OutlookLockStore,
   ) {
-    console.log('MicrosoftAuthService constructor - microsoftConfig:', {
-      clientId: this.microsoftConfig.clientId,
-      redirectUri: this.microsoftConfig.redirectPath,
-    });
+    this.validateConfig(this.microsoftConfig);
 
     this.clientId = this.microsoftConfig.clientId;
     this.clientSecret = this.microsoftConfig.clientSecret;
-
-    // Build the redirect URI based on config
     this.redirectUri = this.buildRedirectUri(this.microsoftConfig);
-    console.log('Redirect URI:', this.redirectUri);
     this.tokenEndpoint = 'https://login.microsoftonline.com/common/oauth2/v2.0/token';
 
-    // Log the redirect URI to help with debugging
     this.logger.log(`Microsoft OAuth redirect URI set to: ${this.redirectUri}`);
+  }
+
+  private validateConfig(config: MicrosoftOutlookConfig): void {
+    const missing: string[] = [];
+    if (!config.clientId) missing.push('clientId');
+    if (!config.clientSecret) missing.push('clientSecret');
+    if (!config.redirectPath) missing.push('redirectPath');
+    if (!config.backendBaseUrl) missing.push('backendBaseUrl');
+
+    if (missing.length > 0) {
+      throw new Error(
+        `MicrosoftOutlookModule is missing required config field(s): ${missing.join(', ')}. ` +
+        'Ensure all required fields are provided when calling MicrosoftOutlookModule.forRoot() or MicrosoftOutlookModule.forRootAsync().',
+      );
+    }
   }
 
   /**


### PR DESCRIPTION

Previously, omitting `redirectPath` (or other required fields) from the module config caused a cryptic TypeError deep in the constructor.  Now `MicrosoftAuthService` runs `validateConfig` before touching any config field and throws a descriptive error naming every missing key. `AppOnlyAuthService.buildAdminConsentRedirectUri` gets the same guard so the same class of bug cannot surface at runtime either.