### PR TITLE
feat: tenant user lifecycle — dedupe subs, disconnect-at-scale, bulk-connect, health

### DIFF
--- a/docs/how-to/connect-enterprise-tenant.md
+++ b/docs/how-to/connect-enterprise-tenant.md
@@ -195,6 +195,33 @@ Microsoft redirects to `/auth/microsoft/tenant/admin-callback` with
 `state == tenantId`, sets its status to `ACTIVE`, and verifies it can acquire a
 token. The tenant is then ready for `TenantCalendarService` / `TenantUserService`.
 
+## Disconnecting a tenant
+
+`DELETE /auth/microsoft/tenant/connection` tears down a tenant connection. It has two modes,
+controlled by query flags:
+
+| Query | Effect |
+|-------|--------|
+| *(none)* | **Soft disconnect.** Flags the `MicrosoftTenant` row inactive (`is_active = false`) and drops the cached app-only token. Mapped `microsoft_users` rows and Outlook webhook subscriptions are **left intact** — re-consent reactivates the tenant and existing mappings keep working. |
+| `?purge=true` | **Full teardown.** Additionally deletes the tenant's Outlook webhook subscriptions at Microsoft (rate-limited) and clears its user mappings: rows that also hold delegated OAuth tokens are unmapped (app-only columns nulled, delegated login preserved), pure app-only rows are deleted — both via bulk SQL. |
+| `?revokeUserTokens=true` | Implies `purge`. Also revokes each delegated refresh token at Microsoft (bounded concurrency) and deletes **all** of the tenant's rows. |
+
+```bash
+# Soft disconnect (default) — keeps mappings and subscriptions
+curl -X DELETE '.../auth/microsoft/tenant/connection?tenantId=<guid>'
+
+# Full teardown — remove subscriptions + user mappings
+curl -X DELETE '.../auth/microsoft/tenant/connection?tenantId=<guid>&purge=true'
+
+# Full teardown + revoke delegated user tokens
+curl -X DELETE '.../auth/microsoft/tenant/connection?tenantId=<guid>&purge=true&revokeUserTokens=true'
+```
+
+When purging, the response includes `subscriptions` and `userMappings` summaries with per-step
+counts. Subscription deletion runs **before** deactivation so it still has a valid app-only
+token; a `404` from Microsoft (subscription already gone) is treated as success and cleaned up
+locally. `tenantId` still defaults to the module-configured tenant when omitted.
+
 ## Using certificate authentication
 
 For production environments, certificate authentication is more secure than client secrets:

--- a/docs/how-to/connect-enterprise-tenant.md
+++ b/docs/how-to/connect-enterprise-tenant.md
@@ -195,6 +195,54 @@ Microsoft redirects to `/auth/microsoft/tenant/admin-callback` with
 `state == tenantId`, sets its status to `ACTIVE`, and verifies it can acquire a
 token. The tenant is then ready for `TenantCalendarService` / `TenantUserService`.
 
+## Bulk-connect users into a tenant
+
+To onboard many users at once, `POST /auth/microsoft/tenant/users/connect` connects a whole list
+in one call. For each user it upserts the `microsoft_users` mapping **and** creates an app-only
+Outlook calendar webhook subscription. Users who already have a delegated subscription have it
+**removed (at Microsoft and locally) before the new one is created**, so a mailbox never ends up
+with two live subscriptions.
+
+Each user must carry an **email/UPN** — an external id alone can't be resolved to a Microsoft
+account (the module looks the user up via Graph `/users?$filter=mail eq …`).
+
+```bash
+curl -X POST '.../auth/microsoft/tenant/users/connect' \
+  -H 'Content-Type: application/json' \
+  -d '{
+        "tenantId": "<guid>",            // optional; defaults to the configured tenant
+        "users": [
+          { "externalUserId": "insp-001", "email": "alice@contoso.com" },
+          { "externalUserId": "insp-002", "email": "bob@contoso.com" }
+        ]
+      }'
+```
+
+Because this can span thousands of users, it runs in the **background** and returns `202 Accepted`
+immediately with `{ message, totalRequested }`. Each user's connect (Graph lookup + optional
+subscription delete + create) runs at **bounded concurrency** — Graph validates each
+subscription's `notificationUrl` at creation, so subscription creation can't be `$batch`ed;
+concurrency is the scale lever. A per-user failure is recorded and never aborts the batch.
+
+Observe the outcome via the emitted event:
+
+```typescript
+import { OnEvent } from '@nestjs/event-emitter';
+import { BulkConnectResult } from '@checkfirst/nestjs-outlook';
+
+@OnEvent('outlook.tenant.users.bulk_connect.completed')
+handleBulkConnect(summary: BulkConnectResult) {
+  // summary: { tenantId, total, connected, failed, results: [{ externalUserId, success, subscriptionId?, error? }] }
+}
+```
+
+A run that can't start (e.g. the tenant isn't connected) emits
+`outlook.tenant.users.bulk_connect.failed` instead. The `TenantProvisioningService.connectUsers()`
+method is also exported for direct (awaitable) use if you'd rather run it inline for small batches.
+
+> **Precondition:** the tenant must already be connected (admin consent granted, `ACTIVE`). See
+> the sections above to register + consent a tenant first.
+
 ## Using certificate authentication
 
 For production environments, certificate authentication is more secure than client secrets:

--- a/docs/how-to/connect-enterprise-tenant.md
+++ b/docs/how-to/connect-enterprise-tenant.md
@@ -224,6 +224,14 @@ subscription delete + create) runs at **bounded concurrency** — Graph validate
 subscription's `notificationUrl` at creation, so subscription creation can't be `$batch`ed;
 concurrency is the scale lever. A per-user failure is recorded and never aborts the batch.
 
+**Already-connected users are skipped.** Before processing, the service checks (in two bulk
+queries) which of the requested users already have an active app-only subscription for the tenant
+and leaves them untouched — so re-running the endpoint (or overlapping batches) never tears down
+and rebuilds a working connection. The summary reports `connected` (newly connected), `skipped`
+(already connected), and `failed`, and each skipped user's result carries `skipped: true`.
+Delegated-only users are **not** treated as connected: they are processed, their `/me/events`
+subscription removed, and an app-only subscription created — after which subsequent runs skip them.
+
 Observe the outcome via the emitted event:
 
 ```typescript
@@ -232,7 +240,8 @@ import { BulkConnectResult } from '@checkfirst/nestjs-outlook';
 
 @OnEvent('outlook.tenant.users.bulk_connect.completed')
 handleBulkConnect(summary: BulkConnectResult) {
-  // summary: { tenantId, total, connected, failed, results: [{ externalUserId, success, subscriptionId?, error? }] }
+  // summary: { tenantId, total, connected, skipped, failed,
+  //            results: [{ externalUserId, success, skipped?, subscriptionId?, error? }] }
 }
 ```
 

--- a/docs/how-to/connect-enterprise-tenant.md
+++ b/docs/how-to/connect-enterprise-tenant.md
@@ -200,27 +200,35 @@ token. The tenant is then ready for `TenantCalendarService` / `TenantUserService
 `DELETE /auth/microsoft/tenant/connection` tears down a tenant connection. It has two modes,
 controlled by query flags:
 
-| Query | Effect |
-|-------|--------|
-| *(none)* | **Soft disconnect.** Flags the `MicrosoftTenant` row inactive (`is_active = false`) and drops the cached app-only token. Mapped `microsoft_users` rows and Outlook webhook subscriptions are **left intact** — re-consent reactivates the tenant and existing mappings keep working. |
-| `?purge=true` | **Full teardown.** Additionally deletes the tenant's Outlook webhook subscriptions at Microsoft (rate-limited) and clears its user mappings: rows that also hold delegated OAuth tokens are unmapped (app-only columns nulled, delegated login preserved), pure app-only rows are deleted — both via bulk SQL. |
-| `?revokeUserTokens=true` | Implies `purge`. Also revokes each delegated refresh token at Microsoft (bounded concurrency) and deletes **all** of the tenant's rows. |
+| Query | Effect | Response |
+|-------|--------|----------|
+| *(none)* | **Soft disconnect** (synchronous). Flags the `MicrosoftTenant` row inactive (`is_active = false`) and drops the cached app-only token. Mapped `microsoft_users` rows and Outlook webhook subscriptions are **left intact** — re-consent reactivates the tenant and existing mappings keep working. | `200` |
+| `?purge=true` | **Full teardown** (runs in the background). Additionally deletes the tenant's Outlook webhook subscriptions at Microsoft (via `$batch`, 20 per call) and clears its user mappings: rows that also hold delegated OAuth tokens are unmapped (app-only columns nulled, delegated login preserved), pure app-only rows are deleted — both via bulk SQL. | `202` |
+| `?revokeUserTokens=true` | Implies `purge`. Also revokes each delegated refresh token at Microsoft (bounded concurrency) and deletes **all** of the tenant's rows. | `202` |
 
 ```bash
-# Soft disconnect (default) — keeps mappings and subscriptions
+# Soft disconnect (default) — keeps mappings and subscriptions (200, synchronous)
 curl -X DELETE '.../auth/microsoft/tenant/connection?tenantId=<guid>'
 
-# Full teardown — remove subscriptions + user mappings
+# Full teardown — remove subscriptions + user mappings (202, runs in background)
 curl -X DELETE '.../auth/microsoft/tenant/connection?tenantId=<guid>&purge=true'
 
-# Full teardown + revoke delegated user tokens
+# Full teardown + revoke delegated user tokens (202)
 curl -X DELETE '.../auth/microsoft/tenant/connection?tenantId=<guid>&purge=true&revokeUserTokens=true'
 ```
 
-When purging, the response includes `subscriptions` and `userMappings` summaries with per-step
-counts. Subscription deletion runs **before** deactivation so it still has a valid app-only
-token; a `404` from Microsoft (subscription already gone) is treated as success and cleaned up
-locally. `tenantId` still defaults to the module-configured tenant when omitted.
+**Why a purge is asynchronous.** A tenant may have thousands of subscriptions and users;
+tearing everything down inline would exceed the request timeout and tie up a worker. The purge
+therefore returns `202 Accepted` immediately and runs in the background. Inside the teardown the
+tenant is deactivated **last**, so subscription deletion still has a valid app-only token while
+it runs, and **the connection reporting as disconnected (`GET connection` returns "not
+connected") is the completion signal** — poll it to know when a purge has finished. A `404` from
+Microsoft (subscription already gone) is treated as success. `tenantId` still defaults to the
+module-configured tenant when omitted.
+
+> **Scale note:** subscription deletion is batched (`$batch`, ≤20/call) and local rows are
+> deactivated in a single bulk `UPDATE`, so the work is roughly O(N/20) Graph round-trips plus a
+> handful of set-based SQL statements — it does not issue one request or one `UPDATE` per user.
 
 ## Using certificate authentication
 

--- a/docs/how-to/connect-enterprise-tenant.md
+++ b/docs/how-to/connect-enterprise-tenant.md
@@ -252,6 +252,44 @@ method is also exported for direct (awaitable) use if you'd rather run it inline
 > **Precondition:** the tenant must already be connected (admin consent granted, `ACTIVE`). See
 > the sections above to register + consent a tenant first.
 
+## Check & recover user health
+
+`HealthService` answers "is this user connected, and if not, why?" by combining the
+`microsoft_users` row and its active Outlook calendar subscription (and, on request, Microsoft
+Graph). It works for one user or a bulk list, covers **delegated and app-only**, and can
+**recover** the fixable states — not just report them.
+
+| Endpoint | Purpose |
+|----------|---------|
+| `GET auth/microsoft/health/:externalUserId?verifyAtGraph=` | One user's verdict |
+| `POST auth/microsoft/health/check` `{ externalUserIds, verifyAtGraph? }` | Bulk verdicts (read-only) |
+| `POST auth/microsoft/health/recover` `{ externalUserIds, verifyAtGraph? }` | Bulk check + recover (background, `202`) |
+
+Verdicts (`UserHealthStatus`): `HEALTHY` · `NO_SUBSCRIPTION` · `SUBSCRIPTION_EXPIRED` ·
+`SUBSCRIPTION_STALE` · `MISSING_AT_GRAPH` (only with `verifyAtGraph`) · `NEEDS_REAUTH` (delegated
+token dead) · `NEEDS_ADMIN` (tenant revoked / cert-expired / disabled) · `NOT_MAPPED` · `INACTIVE`
+· `UNKNOWN`. The first five are **recoverable**; the rest are reported for a human to resolve.
+
+```bash
+# One user, authoritative (also confirms the subscription exists at Microsoft)
+curl '.../auth/microsoft/health/insp-001?verifyAtGraph=true'
+
+# Bulk recover — recreates fixable subscriptions, reports the rest (runs in background)
+curl -X POST '.../auth/microsoft/health/recover' \
+  -H 'Content-Type: application/json' \
+  -d '{ "externalUserIds": ["insp-001","insp-002"], "verifyAtGraph": true }'
+```
+
+Recovery is **auth-mode-aware and idempotent**: an app-only user's subscription is recreated via
+the app-only path, a delegated user's via the delegated path — both remove any stale subscription
+first. `recover` returns `202` and emits `outlook.user.health.recovery.completed` with
+`{ total, healthy, recovered, unrecoverable, failed, results[] }`. `NEEDS_REAUTH` / `NEEDS_ADMIN`
+are never auto-looped — they surface for re-auth / admin action (and the existing
+`USER_REFRESH_TOKEN_INVALID` event still fires for dead delegated tokens).
+
+> This sits **alongside** the built-in 6-hour health-check and 3am retry crons — it adds an
+> on-demand, bulk, app-only-aware entry point; it doesn't replace them.
+
 ## Using certificate authentication
 
 For production environments, certificate authentication is more secure than client secrets:

--- a/docs/reference/subscription-service.md
+++ b/docs/reference/subscription-service.md
@@ -26,12 +26,27 @@ them on a schedule.
 
 | Method | Signature | Returns | Notes |
 |--------|-----------|---------|-------|
-| `createWebhookSubscription` | `(externalUserId: string)` | `Promise<Subscription>` | Creates a Graph subscription and stores it with a generated `clientState`. |
+| `createWebhookSubscription` | `(externalUserId: string)` | `Promise<Subscription>` | Creates a delegated (`/me/events`) Graph subscription and stores it with a generated `clientState`. Removes any existing calendar subscription for the user first (see invariant below). |
+| `createAppOnlyWebhookSubscription` | `(options: AppOnlySubscriptionOptions)` | `Promise<Subscription>` | Creates a tenant-wide app-only (`/users/{id}/events`) subscription. Removes any existing calendar subscription for the user first (see invariant below). |
 | `renewWebhookSubscription` | `(subscriptionId: string, internalUserId: number)` | `Promise<Subscription>` | Renews an existing subscription; recreates it on `404`. |
 | `deleteSubscription` | `(subscriptionId: string, accessToken: string)` | `Promise<void>` | Deletes a single subscription at Graph. |
 | `deleteWebhookSubscription` | `(...)` | `Promise<void>` | Deletes a subscription at Graph and in the local DB. |
 | `deleteAllWebhookSubscriptions` | `(userId: string \| number)` | `Promise<BulkSubscriptionDeleteResult>` | Removes all subscriptions for a user (Graph + DB). |
 | `revokeTokens` | `(refreshToken: string)` | `Promise<void>` | Revokes the user's refresh token at Microsoft. |
+
+### Invariant: one active calendar subscription per user
+
+A user is identified across auth modes by the same internal `userId` on every subscription row
+(delegated rows have `tenantId = null`; app-only rows carry `tenantId` + `microsoftUserId`). Both
+`createWebhookSubscription` and `createAppOnlyWebhookSubscription` therefore remove any
+already-active **calendar** subscription for that user (resource ending in `/events`) before
+creating the new one — deleting it at Microsoft Graph with the token matching the old
+subscription's own auth mode, and deactivating it locally.
+
+This prevents duplicate notifications when a user connected via delegated OAuth is later mapped
+into a tenant (or vice-versa). It is best-effort: a failed Graph delete still deactivates the row
+locally (the subscription expires at Microsoft within ≤3 days) and never blocks creation of the
+new subscription. Email subscriptions (`/me/messages`) are left untouched.
 
 ## Query methods
 

--- a/docs/reference/tenant-user-service.md
+++ b/docs/reference/tenant-user-service.md
@@ -234,6 +234,36 @@ Validates all existing mappings against the tenant directory and removes stale e
 | `removed` | `number` | Stale mappings removed |
 | `errors` | `string[]` | Any errors encountered |
 
+### `clearTenantUserMappings(tenantId, options?)`
+
+Removes a tenant's app-only footprint from the shared `microsoft_users` table during the
+disconnect flow. Runs at most two bulk SQL statements (no per-row loop, no recursion). Used by
+`DELETE /auth/microsoft/tenant/connection?purge=true` — see
+[Disconnecting a tenant](../how-to/connect-enterprise-tenant.md#disconnecting-a-tenant).
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `tenantId` | `string` | Azure AD tenant GUID. Matched regardless of `isActive`, so it works after deactivation. |
+| `options.revokeDelegatedTokens` | `boolean` | Default `false`. When `true`, revoke each delegated refresh token at Microsoft (bounded concurrency) and delete **all** of the tenant's rows. |
+
+**Behaviour:**
+
+- **Default:** rows that also carry delegated OAuth tokens are unmapped (app-only columns nulled,
+  delegated login preserved); pure app-only rows are deleted.
+- **`revokeDelegatedTokens: true`:** delegated tokens are revoked (best-effort — failures are
+  counted, never fatal), then every row for the tenant is deleted.
+
+**Returns:** `Promise<ClearTenantMappingsResult>`
+
+**ClearTenantMappingsResult:**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `delegatedRowsUnmapped` | `number` | Dual-capability rows unmapped (app-only columns nulled). |
+| `appOnlyRowsDeleted` | `number` | Rows deleted. |
+| `tokensRevoked` | `number` | Delegated refresh tokens revoked at Microsoft. |
+| `tokenRevocationFailures` | `number` | Revocations that failed (teardown continued regardless). |
+
 ## Caching
 
 The service maintains an in-memory cache for user mappings:

--- a/src/controllers/health.controller.ts
+++ b/src/controllers/health.controller.ts
@@ -1,0 +1,135 @@
+import {
+  Controller, Get, Post, Param, Query, Body, Res, HttpStatus, Logger, Optional, Inject, BadRequestException,
+} from '@nestjs/common';
+import { Response } from 'express';
+import { ApiTags, ApiOperation, ApiParam, ApiQuery, ApiBody, ApiResponse } from '@nestjs/swagger';
+import { HealthService, UserHealth } from '../services/health/health.service';
+import { HealthCheckDto } from '../dto/health-check.dto';
+
+/**
+ * Endpoints to diagnose and recover user connection health (delegated + app-only).
+ */
+@ApiTags('Health')
+@Controller('auth/microsoft/health')
+export class HealthController {
+  private readonly logger = new Logger(HealthController.name);
+
+  constructor(
+    @Optional()
+    @Inject(HealthService)
+    private readonly healthService: HealthService | null,
+  ) {}
+
+  /**
+   * Diagnose a single user's connection health.
+   */
+  @Get(':externalUserId')
+  @ApiOperation({
+    summary: 'Get one user\'s connection health',
+    description:
+      'Returns a health verdict combining the microsoft_users row and its active calendar ' +
+      'subscription. Pass verifyAtGraph=true to also confirm the subscription exists at Microsoft.',
+  })
+  @ApiParam({ name: 'externalUserId', description: "The host application's user id", example: 'insp-001' })
+  @ApiQuery({ name: 'verifyAtGraph', required: false, type: Boolean })
+  @ApiResponse({ status: 200, description: 'Health verdict for the user' })
+  async getUserHealth(
+    @Param('externalUserId') externalUserId: string,
+    @Query('verifyAtGraph') verifyAtGraph?: string,
+  ): Promise<UserHealth> {
+    const service = this.requireService();
+    return service.checkUser(externalUserId, { verifyAtGraph: this.isTruthy(verifyAtGraph) });
+  }
+
+  /**
+   * Diagnose a batch of users (read-only).
+   */
+  @Post('check')
+  @ApiOperation({
+    summary: 'Check connection health for many users',
+    description: 'Read-only bulk health verdicts. Set verifyAtGraph to also confirm each at Microsoft.',
+  })
+  @ApiBody({ type: HealthCheckDto })
+  @ApiResponse({ status: 200, description: 'Health verdicts (input order preserved)' })
+  async checkUsers(@Body() body: HealthCheckDto): Promise<UserHealth[]> {
+    const service = this.requireService();
+    const externalUserIds = this.validateExternalUserIds(body);
+    return service.checkUsers(externalUserIds, { verifyAtGraph: this.isTruthy(body.verifyAtGraph) });
+  }
+
+  /**
+   * Diagnose and recover a batch of users. Recreates fixable subscriptions (delegated or app-only)
+   * and reports the rest. Runs in the background and returns 202; listen for the
+   * `outlook.user.health.recovery.completed` event for the summary.
+   */
+  @Post('recover')
+  @ApiOperation({
+    summary: 'Check and recover many users',
+    description:
+      'Auto-fixes recoverable users (recreates missing/expired/stale/gone-at-Graph subscriptions) ' +
+      'and reports those needing a human. Runs in the background (202); listen for the ' +
+      "'outlook.user.health.recovery.completed' event for the result.",
+  })
+  @ApiBody({ type: HealthCheckDto })
+  @ApiResponse({ status: 202, description: 'Recovery accepted and running in the background' })
+  @ApiResponse({ status: 400, description: 'Invalid body' })
+  recoverUsers(
+    @Body() body: HealthCheckDto,
+    @Res({ passthrough: true }) res?: Response,
+  ): { message: string; totalRequested: number } {
+    const service = this.requireService();
+    const externalUserIds = this.validateExternalUserIds(body);
+    const verifyAtGraph = this.isTruthy(body.verifyAtGraph);
+
+    // Recovery does per-user Graph work — run detached so a large batch can't time out the request.
+    service.recoverUsers(externalUserIds, { verifyAtGraph }).catch((error: unknown) => {
+      this.logger.error(
+        `[recoverUsers] Background health recovery failed: ${
+          error instanceof Error ? error.message : 'Unknown error'
+        }`,
+      );
+    });
+
+    if (res) {
+      res.status(HttpStatus.ACCEPTED);
+    }
+    return {
+      message:
+        'Health recovery is running in the background. Listen for the ' +
+        "'outlook.user.health.recovery.completed' event for the result.",
+      totalRequested: externalUserIds.length,
+    };
+  }
+
+  private requireService(): HealthService {
+    if (!this.healthService) {
+      throw new Error('Health service is not available in this application');
+    }
+    return this.healthService;
+  }
+
+  /** Validate the request body's user id list (no class-transformer, so validated here). */
+  private validateExternalUserIds(body: HealthCheckDto): string[] {
+    const raw: unknown = body.externalUserIds;
+    if (!Array.isArray(raw) || raw.length === 0) {
+      throw new BadRequestException('`externalUserIds` must be a non-empty array');
+    }
+    for (const id of raw) {
+      if (typeof id !== 'string' || id.trim() === '') {
+        throw new BadRequestException('each externalUserId must be a non-empty string');
+      }
+    }
+    return raw as string[];
+  }
+
+  private isTruthy(value: string | boolean | undefined): boolean {
+    if (typeof value === 'boolean') {
+      return value;
+    }
+    if (typeof value === 'string') {
+      const v = value.trim().toLowerCase();
+      return v === 'true' || v === '1' || v === 'yes';
+    }
+    return false;
+  }
+}

--- a/src/controllers/tenant-auth.controller.ts
+++ b/src/controllers/tenant-auth.controller.ts
@@ -5,6 +5,8 @@ import { AppOnlyAuthService } from '../services/auth/app-only-auth.service';
 import { MicrosoftTenantRepository } from '../repositories/microsoft-tenant.repository';
 import { MicrosoftTenant } from '../entities/microsoft-tenant.entity';
 import { MicrosoftTenantStatus } from '../enums/microsoft-tenant-status.enum';
+import { TenantUserService, ClearTenantMappingsResult } from '../services/tenant/tenant-user.service';
+import { MicrosoftSubscriptionService, BulkSubscriptionDeleteResult } from '../services/subscription/microsoft-subscription.service';
 
 /**
  * Controller for handling tenant-wide (app-only) authentication flows.
@@ -36,6 +38,14 @@ export class TenantAuthController {
     @Optional()
     @Inject(MicrosoftTenantRepository)
     private readonly tenantConnectionRepository: MicrosoftTenantRepository | null,
+    // Optional teardown collaborators — only needed for the `purge` disconnect path.
+    // Same `| null` reflection caveat as above: explicit @Inject token + @Optional.
+    @Optional()
+    @Inject(TenantUserService)
+    private readonly tenantUserService: TenantUserService | null,
+    @Optional()
+    @Inject(MicrosoftSubscriptionService)
+    private readonly subscriptionService: MicrosoftSubscriptionService | null,
   ) {}
 
   /**
@@ -405,14 +415,25 @@ export class TenantAuthController {
    * @description Deactivates the stored tenant connection and invalidates any cached
    * app-only access token so subsequent Graph calls stop working until re-consent.
    *
+   * By default this is a **soft** disconnect: the tenant row is flagged inactive and its
+   * token cache dropped, but the mapped `microsoft_users` rows and any Outlook webhook
+   * subscriptions are left in place. Pass `purge=true` for a **full teardown** that also
+   * deletes the tenant's Outlook subscriptions at Microsoft and clears its user mappings.
+   * Add `revokeUserTokens=true` to additionally revoke and remove delegated user tokens.
+   *
    * @param {string} tenantId - Optional Azure AD tenant ID; defaults to the configured tenant
-   * @returns {{ message: string }} Confirmation message
+   * @param {boolean} purge - Also delete Outlook subscriptions and clear user mappings
+   * @param {boolean} revokeUserTokens - With purge, also revoke/remove delegated user tokens
+   * @returns Confirmation message, plus a teardown summary when purging
    */
   @Delete('connection')
   @ApiOperation({
     summary: 'Disconnect the tenant connection',
     description:
-      'Deactivates the stored app-only tenant connection and invalidates the cached access token. Falls back to the module-configured tenant when tenantId is omitted.',
+      'Deactivates the stored app-only tenant connection and invalidates the cached access token. ' +
+      'With purge=true, also deletes the tenant\'s Outlook webhook subscriptions at Microsoft (rate-limited) ' +
+      'and clears its user mappings; with revokeUserTokens=true it additionally revokes delegated tokens. ' +
+      'Falls back to the module-configured tenant when tenantId is omitted.',
   })
   @ApiQuery({
     name: 'tenantId',
@@ -421,14 +442,41 @@ export class TenantAuthController {
     type: String,
     example: '12345678-1234-1234-1234-123456789abc',
   })
+  @ApiQuery({
+    name: 'purge',
+    description: 'Also delete Outlook subscriptions and clear user mappings for the tenant',
+    required: false,
+    type: Boolean,
+    example: true,
+  })
+  @ApiQuery({
+    name: 'revokeUserTokens',
+    description: 'With purge, revoke and remove delegated user tokens (implies purge)',
+    required: false,
+    type: Boolean,
+    example: false,
+  })
   @ApiResponse({
     status: 200,
     description: 'Tenant disconnected (or nothing to disconnect)',
   })
-  async disconnect(@Query('tenantId') tenantId?: string): Promise<{ message: string }> {
+  async disconnect(
+    @Query('tenantId') tenantId?: string,
+    @Query('purge') purge?: string | boolean,
+    @Query('revokeUserTokens') revokeUserTokens?: string | boolean,
+  ): Promise<{
+    message: string;
+    subscriptions?: BulkSubscriptionDeleteResult;
+    userMappings?: ClearTenantMappingsResult;
+  }> {
     if (!this.appOnlyAuthService || !this.tenantConnectionRepository) {
       throw new Error('Tenant-wide authentication is not configured for this application');
     }
+
+    // Query params arrive as strings ('true'/'false'); coerce leniently. revokeUserTokens
+    // implies purge — you can't revoke tokens without tearing down the mappings.
+    const revokeTokens = this.isTruthyFlag(revokeUserTokens);
+    const shouldPurge = this.isTruthyFlag(purge) || revokeTokens;
 
     // Resolve which tenant to disconnect, mirroring getConnection: an explicit tenantId
     // wins; otherwise use the module-configured tenant when concrete; otherwise (the
@@ -454,11 +502,61 @@ export class TenantAuthController {
       return { message: 'No tenant connection to disconnect.' };
     }
 
+    const response: {
+      message: string;
+      subscriptions?: BulkSubscriptionDeleteResult;
+      userMappings?: ClearTenantMappingsResult;
+    } = { message: 'Microsoft 365 tenant disconnected successfully.' };
+
+    // Full teardown runs BEFORE deactivation so subscription deletion still has a valid
+    // app-only token (findByTenantId only returns active rows once deactivated).
+    if (shouldPurge) {
+      if (this.subscriptionService) {
+        response.subscriptions =
+          await this.subscriptionService.deleteAllAppOnlySubscriptionsForTenant(resolvedTenantId);
+      } else {
+        this.logger.warn(
+          `[disconnect] purge requested but subscription service is unavailable; ` +
+          `skipping Outlook subscription cleanup for ${resolvedTenantId}`,
+        );
+      }
+
+      if (this.tenantUserService) {
+        response.userMappings = await this.tenantUserService.clearTenantUserMappings(
+          resolvedTenantId,
+          { revokeDelegatedTokens: revokeTokens },
+        );
+      } else {
+        this.logger.warn(
+          `[disconnect] purge requested but tenant user service is unavailable; ` +
+          `skipping user-mapping cleanup for ${resolvedTenantId}`,
+        );
+      }
+    }
+
     await this.tenantConnectionRepository.deactivate(resolvedTenantId);
     this.appOnlyAuthService.invalidateCache(resolvedTenantId);
-    this.logger.log(`Tenant connection disconnected: ${resolvedTenantId}`);
+    this.logger.log(
+      `Tenant connection disconnected: ${resolvedTenantId} (purge=${shouldPurge}, revokeUserTokens=${revokeTokens})`,
+    );
 
-    return { message: 'Microsoft 365 tenant disconnected successfully.' };
+    return response;
+  }
+
+  /**
+   * Coerce a query-string flag to boolean. Query params are strings, so treat
+   * 'true'/'1'/'yes' (case-insensitive) and boolean `true` as truthy; everything
+   * else (including undefined and 'false') is false.
+   */
+  private isTruthyFlag(value: string | boolean | undefined): boolean {
+    if (typeof value === 'boolean') {
+      return value;
+    }
+    if (typeof value === 'string') {
+      const normalized = value.trim().toLowerCase();
+      return normalized === 'true' || normalized === '1' || normalized === 'yes';
+    }
+    return false;
   }
 
   /**

--- a/src/controllers/tenant-auth.controller.ts
+++ b/src/controllers/tenant-auth.controller.ts
@@ -1,10 +1,12 @@
-import { Controller, Get, Delete, Query, Logger, Res, HttpStatus, Optional, Inject } from '@nestjs/common';
+import { Controller, Get, Delete, Post, Body, Query, Logger, Res, HttpStatus, Optional, Inject, BadRequestException } from '@nestjs/common';
 import { Response } from 'express';
-import { ApiTags, ApiResponse, ApiQuery, ApiOperation, ApiProduces } from '@nestjs/swagger';
+import { ApiTags, ApiResponse, ApiQuery, ApiBody, ApiOperation, ApiProduces } from '@nestjs/swagger';
 import { AppOnlyAuthService } from '../services/auth/app-only-auth.service';
 import { MicrosoftTenantRepository } from '../repositories/microsoft-tenant.repository';
 import { MicrosoftTenant } from '../entities/microsoft-tenant.entity';
 import { MicrosoftTenantStatus } from '../enums/microsoft-tenant-status.enum';
+import { TenantProvisioningService } from '../services/tenant/tenant-provisioning.service';
+import { BulkConnectUsersDto } from '../dto/bulk-connect-users.dto';
 
 /**
  * Controller for handling tenant-wide (app-only) authentication flows.
@@ -36,6 +38,9 @@ export class TenantAuthController {
     @Optional()
     @Inject(MicrosoftTenantRepository)
     private readonly tenantConnectionRepository: MicrosoftTenantRepository | null,
+    @Optional()
+    @Inject(TenantProvisioningService)
+    private readonly provisioningService: TenantProvisioningService | null,
   ) {}
 
   /**
@@ -396,6 +401,102 @@ export class TenantAuthController {
 
     const activeConnections = await this.tenantConnectionRepository.findAllActive();
     return activeConnections[0] ?? null;
+  }
+
+  /**
+   * Bulk-connect users into a tenant (app-only).
+   *
+   * @summary Connect many users into a tenant
+   * @description For each `{ externalUserId, email }` the module upserts the `microsoft_users`
+   * mapping and creates an app-only Outlook calendar webhook subscription. Users who already
+   * have a delegated subscription have it removed (at Microsoft and locally) before the new one
+   * is created, so a mailbox never ends up double-subscribed.
+   *
+   * Because this can span thousands of users, it runs in the **background** and returns
+   * `202 Accepted` immediately. Listen for the
+   * `outlook.tenant.users.bulk_connect.completed` event (payload includes per-user results and
+   * connected/failed tallies) to observe the outcome.
+   *
+   * @param {BulkConnectUsersDto} body - Tenant (optional; defaults to configured) + users list
+   * @returns Acknowledgement with the number of users queued
+   */
+  @Post('users/connect')
+  @ApiOperation({
+    summary: 'Bulk-connect users into a tenant',
+    description:
+      'Upserts each user mapping and creates an app-only Outlook calendar subscription per user; ' +
+      'existing calendar subscriptions are removed before recreation. Runs in the background and ' +
+      "returns 202 — listen for the 'outlook.tenant.users.bulk_connect.completed' event for results.",
+  })
+  @ApiBody({ type: BulkConnectUsersDto })
+  @ApiResponse({
+    status: 202,
+    description: 'Bulk connect accepted and running in the background',
+  })
+  @ApiResponse({
+    status: 400,
+    description: 'Invalid body, or no tenant to connect into',
+  })
+  connectUsers(
+    @Body() body: BulkConnectUsersDto,
+    @Res({ passthrough: true }) res?: Response,
+  ): { message: string; totalRequested: number } {
+    if (!this.appOnlyAuthService || !this.provisioningService) {
+      throw new Error('Tenant-wide authentication is not configured for this application');
+    }
+
+    // Validate the body here: this package doesn't depend on class-transformer, so the nested
+    // `users` items aren't deep-validated by a global ValidationPipe. Treat items as unknown so
+    // the runtime checks are meaningful (the DTO type alone would make them look redundant).
+    const rawUsers: unknown = body.users;
+    if (!Array.isArray(rawUsers) || rawUsers.length === 0) {
+      throw new BadRequestException('`users` must be a non-empty array');
+    }
+    for (const item of rawUsers) {
+      const user = item as { externalUserId?: unknown; email?: unknown };
+      if (
+        typeof user.externalUserId !== 'string' || user.externalUserId.trim() === '' ||
+        typeof user.email !== 'string' || user.email.trim() === ''
+      ) {
+        throw new BadRequestException('each user must have a non-empty `externalUserId` and `email`');
+      }
+    }
+
+    // Resolve the tenant: explicit body value wins; otherwise the module-configured concrete
+    // tenant ('common' is the dynamic-tenant placeholder and can't be defaulted to).
+    let tenantId = body.tenantId;
+    if (!tenantId) {
+      const configured = this.appOnlyAuthService.getTenantId();
+      if (configured && configured !== 'common') {
+        tenantId = configured;
+      }
+    }
+    if (!tenantId) {
+      throw new BadRequestException(
+        'tenantId is required (no concrete module-configured tenant to default to)',
+      );
+    }
+
+    // Run in the background — a synchronous connect of thousands of users would blow the
+    // request timeout and pin a worker. Detached and fully defensive; results arrive via event.
+    const targetTenantId = tenantId;
+    this.provisioningService.connectUsers(targetTenantId, body.users).catch((error: unknown) => {
+      this.logger.error(
+        `[connectUsers] Background bulk connect failed for ${targetTenantId}: ${
+          error instanceof Error ? error.message : 'Unknown error'
+        }`,
+      );
+    });
+
+    if (res) {
+      res.status(HttpStatus.ACCEPTED);
+    }
+    return {
+      message:
+        'Bulk user connect is running in the background. Listen for the ' +
+        "'outlook.tenant.users.bulk_connect.completed' event for the result.",
+      totalRequested: rawUsers.length,
+    };
   }
 
   /**

--- a/src/controllers/tenant-auth.controller.ts
+++ b/src/controllers/tenant-auth.controller.ts
@@ -5,8 +5,8 @@ import { AppOnlyAuthService } from '../services/auth/app-only-auth.service';
 import { MicrosoftTenantRepository } from '../repositories/microsoft-tenant.repository';
 import { MicrosoftTenant } from '../entities/microsoft-tenant.entity';
 import { MicrosoftTenantStatus } from '../enums/microsoft-tenant-status.enum';
-import { TenantUserService, ClearTenantMappingsResult } from '../services/tenant/tenant-user.service';
-import { MicrosoftSubscriptionService, BulkSubscriptionDeleteResult } from '../services/subscription/microsoft-subscription.service';
+import { TenantUserService } from '../services/tenant/tenant-user.service';
+import { MicrosoftSubscriptionService } from '../services/subscription/microsoft-subscription.service';
 
 /**
  * Controller for handling tenant-wide (app-only) authentication flows.
@@ -415,25 +415,31 @@ export class TenantAuthController {
    * @description Deactivates the stored tenant connection and invalidates any cached
    * app-only access token so subsequent Graph calls stop working until re-consent.
    *
-   * By default this is a **soft** disconnect: the tenant row is flagged inactive and its
-   * token cache dropped, but the mapped `microsoft_users` rows and any Outlook webhook
-   * subscriptions are left in place. Pass `purge=true` for a **full teardown** that also
-   * deletes the tenant's Outlook subscriptions at Microsoft and clears its user mappings.
-   * Add `revokeUserTokens=true` to additionally revoke and remove delegated user tokens.
+   * By default this is a **soft** disconnect (synchronous, `200`): the tenant row is flagged
+   * inactive and its token cache dropped, but the mapped `microsoft_users` rows and any Outlook
+   * webhook subscriptions are left in place. Pass `purge=true` for a **full teardown** that also
+   * deletes the tenant's Outlook subscriptions at Microsoft and clears its user mappings; add
+   * `revokeUserTokens=true` to additionally revoke and remove delegated user tokens.
+   *
+   * Because a purge can touch thousands of subscriptions/users, it runs in the **background**
+   * and the endpoint returns `202 Accepted` immediately. The tenant is deactivated at the end
+   * of the teardown, so the connection reporting as disconnected (via `GET connection`) is the
+   * completion signal.
    *
    * @param {string} tenantId - Optional Azure AD tenant ID; defaults to the configured tenant
-   * @param {boolean} purge - Also delete Outlook subscriptions and clear user mappings
+   * @param {boolean} purge - Also delete Outlook subscriptions and clear user mappings (async)
    * @param {boolean} revokeUserTokens - With purge, also revoke/remove delegated user tokens
-   * @returns Confirmation message, plus a teardown summary when purging
+   * @returns Confirmation message (`202` when a purge was started, `200` for a soft disconnect)
    */
   @Delete('connection')
   @ApiOperation({
     summary: 'Disconnect the tenant connection',
     description:
-      'Deactivates the stored app-only tenant connection and invalidates the cached access token. ' +
-      'With purge=true, also deletes the tenant\'s Outlook webhook subscriptions at Microsoft (rate-limited) ' +
-      'and clears its user mappings; with revokeUserTokens=true it additionally revokes delegated tokens. ' +
-      'Falls back to the module-configured tenant when tenantId is omitted.',
+      'Soft disconnect (default) deactivates the stored app-only tenant connection and invalidates ' +
+      'the cached access token, synchronously (200). With purge=true it additionally deletes the ' +
+      'tenant\'s Outlook webhook subscriptions at Microsoft (batched) and clears its user mappings; ' +
+      'with revokeUserTokens=true it also revokes delegated tokens. A purge runs in the background ' +
+      'and returns 202 immediately. Falls back to the module-configured tenant when tenantId is omitted.',
   })
   @ApiQuery({
     name: 'tenantId',
@@ -444,7 +450,7 @@ export class TenantAuthController {
   })
   @ApiQuery({
     name: 'purge',
-    description: 'Also delete Outlook subscriptions and clear user mappings for the tenant',
+    description: 'Also delete Outlook subscriptions and clear user mappings (runs in background)',
     required: false,
     type: Boolean,
     example: true,
@@ -458,17 +464,18 @@ export class TenantAuthController {
   })
   @ApiResponse({
     status: 200,
-    description: 'Tenant disconnected (or nothing to disconnect)',
+    description: 'Soft disconnect completed (or nothing to disconnect)',
+  })
+  @ApiResponse({
+    status: 202,
+    description: 'Purge accepted and running in the background',
   })
   async disconnect(
     @Query('tenantId') tenantId?: string,
     @Query('purge') purge?: string | boolean,
     @Query('revokeUserTokens') revokeUserTokens?: string | boolean,
-  ): Promise<{
-    message: string;
-    subscriptions?: BulkSubscriptionDeleteResult;
-    userMappings?: ClearTenantMappingsResult;
-  }> {
+    @Res({ passthrough: true }) res?: Response,
+  ): Promise<{ message: string }> {
     if (!this.appOnlyAuthService || !this.tenantConnectionRepository) {
       throw new Error('Tenant-wide authentication is not configured for this application');
     }
@@ -502,45 +509,104 @@ export class TenantAuthController {
       return { message: 'No tenant connection to disconnect.' };
     }
 
-    const response: {
-      message: string;
-      subscriptions?: BulkSubscriptionDeleteResult;
-      userMappings?: ClearTenantMappingsResult;
-    } = { message: 'Microsoft 365 tenant disconnected successfully.' };
-
-    // Full teardown runs BEFORE deactivation so subscription deletion still has a valid
-    // app-only token (findByTenantId only returns active rows once deactivated).
     if (shouldPurge) {
-      if (this.subscriptionService) {
-        response.subscriptions =
-          await this.subscriptionService.deleteAllAppOnlySubscriptionsForTenant(resolvedTenantId);
-      } else {
-        this.logger.warn(
-          `[disconnect] purge requested but subscription service is unavailable; ` +
-          `skipping Outlook subscription cleanup for ${resolvedTenantId}`,
+      // A full teardown can touch thousands of subscriptions/users — far too slow to run in
+      // the request without blowing the HTTP timeout and pinning a worker. Kick it off in the
+      // background (detached, fully defensive) and return 202 immediately. The tenant is
+      // deactivated at the END of runTenantPurge so subscription deletion still has a valid
+      // app-only token while it runs.
+      const purgeTenantId = resolvedTenantId;
+      this.runTenantPurge(purgeTenantId, revokeTokens).catch((error: unknown) => {
+        this.logger.error(
+          `[disconnect] Background purge failed for ${purgeTenantId}: ${
+            error instanceof Error ? error.message : 'Unknown error'
+          }`,
         );
-      }
+      });
 
-      if (this.tenantUserService) {
-        response.userMappings = await this.tenantUserService.clearTenantUserMappings(
-          resolvedTenantId,
-          { revokeDelegatedTokens: revokeTokens },
-        );
-      } else {
-        this.logger.warn(
-          `[disconnect] purge requested but tenant user service is unavailable; ` +
-          `skipping user-mapping cleanup for ${resolvedTenantId}`,
-        );
+      if (res) {
+        res.status(HttpStatus.ACCEPTED);
       }
+      return {
+        message:
+          'Microsoft 365 tenant disconnect is running in the background. ' +
+          'The connection will report as disconnected once teardown completes.',
+      };
     }
 
+    // Soft disconnect — cheap, so do it synchronously and return 200.
     await this.tenantConnectionRepository.deactivate(resolvedTenantId);
     this.appOnlyAuthService.invalidateCache(resolvedTenantId);
+    this.logger.log(`Tenant connection disconnected: ${resolvedTenantId} (soft)`);
+
+    return { message: 'Microsoft 365 tenant disconnected successfully.' };
+  }
+
+  /**
+   * Run the full tenant teardown in the background: delete Outlook subscriptions at Microsoft
+   * (batched via `$batch`), clear user mappings, then deactivate the tenant and drop its token
+   * cache LAST — so the earlier steps still had a live token/tenant to work with. Fully
+   * defensive: each step is isolated, logs on failure, and never rejects the caller. Progress
+   * is observable via the tenant flipping to inactive (`GET connection`) once this completes.
+   *
+   * @param tenantId - Azure AD tenant GUID being torn down.
+   * @param revokeTokens - Whether to revoke + delete delegated user tokens as well.
+   */
+  private async runTenantPurge(tenantId: string, revokeTokens: boolean): Promise<void> {
     this.logger.log(
-      `Tenant connection disconnected: ${resolvedTenantId} (purge=${shouldPurge}, revokeUserTokens=${revokeTokens})`,
+      `[purge] Starting background teardown for tenant ${tenantId} (revokeUserTokens=${revokeTokens})`,
     );
 
-    return response;
+    if (this.subscriptionService) {
+      try {
+        const subs = await this.subscriptionService.deleteAllAppOnlySubscriptionsForTenant(tenantId);
+        this.logger.log(
+          `[purge] ${tenantId} subscriptions: ${subs.totalFound} found, ` +
+          `${subs.successfullyDeleted} deleted, ${subs.failedToDelete} failed`,
+        );
+      } catch (error) {
+        this.logger.error(
+          `[purge] Subscription cleanup failed for ${tenantId}: ${
+            error instanceof Error ? error.message : 'Unknown error'
+          }`,
+        );
+      }
+    } else {
+      this.logger.warn(
+        `[purge] Subscription service unavailable; skipping subscription cleanup for ${tenantId}`,
+      );
+    }
+
+    if (this.tenantUserService) {
+      try {
+        const mappings = await this.tenantUserService.clearTenantUserMappings(tenantId, {
+          revokeDelegatedTokens: revokeTokens,
+        });
+        this.logger.log(
+          `[purge] ${tenantId} mappings: ${mappings.delegatedRowsUnmapped} unmapped, ` +
+          `${mappings.appOnlyRowsDeleted} deleted, ${mappings.tokensRevoked} tokens revoked`,
+        );
+      } catch (error) {
+        this.logger.error(
+          `[purge] User-mapping cleanup failed for ${tenantId}: ${
+            error instanceof Error ? error.message : 'Unknown error'
+          }`,
+        );
+      }
+    } else {
+      this.logger.warn(
+        `[purge] Tenant user service unavailable; skipping user-mapping cleanup for ${tenantId}`,
+      );
+    }
+
+    // Deactivate + invalidate LAST so the steps above had a live token/tenant to work with.
+    if (this.tenantConnectionRepository && this.appOnlyAuthService) {
+      await this.tenantConnectionRepository.deactivate(tenantId);
+      this.appOnlyAuthService.invalidateCache(tenantId);
+    }
+    this.logger.log(
+      `[purge] Background teardown complete for tenant ${tenantId}; connection deactivated`,
+    );
   }
 
   /**

--- a/src/dto/bulk-connect-users.dto.ts
+++ b/src/dto/bulk-connect-users.dto.ts
@@ -1,0 +1,46 @@
+import { IsString, IsOptional, IsArray, ArrayNotEmpty } from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+
+/**
+ * One user to bulk-connect into a tenant. `email` (or UPN) is required — the module resolves
+ * the Microsoft account by email/UPN, so an external id alone is not enough.
+ */
+export class BulkConnectUserDto {
+  @ApiProperty({
+    description: "The host application's user identifier.",
+    example: 'insp-001',
+  })
+  @IsString()
+  externalUserId!: string;
+
+  @ApiProperty({
+    description: 'Email or user principal name (UPN) that exists in the tenant.',
+    example: 'john.doe@contoso.com',
+  })
+  @IsString()
+  email!: string;
+}
+
+/**
+ * Request body for bulk-connecting users into a tenant.
+ *
+ * Note: nested-item validation is performed in the controller (this package does not depend on
+ * `class-transformer`, so `@ValidateNested`/`@Type` are intentionally not used here).
+ */
+export class BulkConnectUsersDto {
+  @ApiPropertyOptional({
+    description: 'Azure AD tenant GUID. Defaults to the module-configured tenant when omitted.',
+    example: '12345678-1234-1234-1234-123456789abc',
+  })
+  @IsOptional()
+  @IsString()
+  tenantId?: string;
+
+  @ApiProperty({
+    description: 'Users to connect into the tenant.',
+    type: [BulkConnectUserDto],
+  })
+  @IsArray()
+  @ArrayNotEmpty()
+  users!: BulkConnectUserDto[];
+}

--- a/src/dto/health-check.dto.ts
+++ b/src/dto/health-check.dto.ts
@@ -1,0 +1,27 @@
+import { IsOptional, IsArray, ArrayNotEmpty, IsBoolean } from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+
+/**
+ * Request body for bulk health check / recover.
+ *
+ * Note: the `externalUserIds` items are validated in the controller (this package does not depend
+ * on `class-transformer`, so array-of-primitives deep validation isn't done by a ValidationPipe).
+ */
+export class HealthCheckDto {
+  @ApiProperty({
+    description: "Host application user identifiers to check.",
+    type: [String],
+    example: ['insp-001', 'insp-002'],
+  })
+  @IsArray()
+  @ArrayNotEmpty()
+  externalUserIds!: string[];
+
+  @ApiPropertyOptional({
+    description: 'Also verify each subscription still exists at Microsoft Graph (extra Graph calls).',
+    example: false,
+  })
+  @IsOptional()
+  @IsBoolean()
+  verifyAtGraph?: boolean;
+}

--- a/src/enums/event-types.enum.ts
+++ b/src/enums/event-types.enum.ts
@@ -40,4 +40,8 @@ export enum OutlookEventTypes {
 
   // Security events
   WEBHOOK_REJECTED = 'outlook.webhook.rejected',
+
+  // Tenant provisioning events
+  TENANT_USERS_BULK_CONNECT_COMPLETED = 'outlook.tenant.users.bulk_connect.completed',
+  TENANT_USERS_BULK_CONNECT_FAILED = 'outlook.tenant.users.bulk_connect.failed',
 }

--- a/src/enums/event-types.enum.ts
+++ b/src/enums/event-types.enum.ts
@@ -44,4 +44,8 @@ export enum OutlookEventTypes {
   // Tenant provisioning events
   TENANT_USERS_BULK_CONNECT_COMPLETED = 'outlook.tenant.users.bulk_connect.completed',
   TENANT_USERS_BULK_CONNECT_FAILED = 'outlook.tenant.users.bulk_connect.failed',
+
+  // Health / recovery events
+  USER_HEALTH_RECOVERY_COMPLETED = 'outlook.user.health.recovery.completed',
+  USER_HEALTH_RECOVERY_FAILED = 'outlook.user.health.recovery.failed',
 }

--- a/src/enums/user-health-status.enum.ts
+++ b/src/enums/user-health-status.enum.ts
@@ -1,0 +1,30 @@
+/**
+ * Connection-health verdict for a single user, combining the `microsoft_users` row, its active
+ * Outlook webhook subscription, and (optionally) Microsoft Graph. Only `HEALTHY` means "connected".
+ */
+export enum UserHealthStatus {
+  /** Active user with a live calendar subscription. Connected. */
+  HEALTHY = 'HEALTHY',
+
+  // ── recoverable (auto-fixable by recreating the subscription) ──
+  /** Mapped/active user but no active calendar subscription. */
+  NO_SUBSCRIPTION = 'NO_SUBSCRIPTION',
+  /** Subscription exists but has passed its expiration. */
+  SUBSCRIPTION_EXPIRED = 'SUBSCRIPTION_EXPIRED',
+  /** Subscription active locally but no notification received within the stale window. */
+  SUBSCRIPTION_STALE = 'SUBSCRIPTION_STALE',
+  /** Subscription active locally but returns 404 at Microsoft (only when verifyAtGraph is set). */
+  MISSING_AT_GRAPH = 'MISSING_AT_GRAPH',
+
+  // ── not auto-recoverable (reported, needs a human) ──
+  /** Delegated user whose token is dead (status CORRUPTED) — needs re-authentication. */
+  NEEDS_REAUTH = 'NEEDS_REAUTH',
+  /** App-only tenant is revoked / cert-expired / disabled — needs an administrator. */
+  NEEDS_ADMIN = 'NEEDS_ADMIN',
+  /** App-only user with no tenant mapping (cannot recover without an email/UPN here). */
+  NOT_MAPPED = 'NOT_MAPPED',
+  /** Row is soft-deleted (`isActive = false`). */
+  INACTIVE = 'INACTIVE',
+  /** No `microsoft_users` row exists for this external id. */
+  UNKNOWN = 'UNKNOWN',
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,7 @@ export * from './services/shared/outlook-lock.store';
 export * from './services/shared/outlook-rate-limit.store';
 export * from './services/tenant/tenant-calendar.service';
 export * from './services/tenant/tenant-user.service';
+export * from './services/tenant/tenant-provisioning.service';
 
 // Export module
 export * from './microsoft-outlook.module';
@@ -46,6 +47,7 @@ export * from './controllers/email.controller';
 
 // Export DTOs
 export * from './dto/outlook-webhook-notification.dto';
+export * from './dto/bulk-connect-users.dto';
 
 // Entities
 export * from './entities/outlook-webhook-subscription.entity';

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,7 @@ export * from './services/shared/outlook-rate-limit.store';
 export * from './services/tenant/tenant-calendar.service';
 export * from './services/tenant/tenant-user.service';
 export * from './services/tenant/tenant-provisioning.service';
+export * from './services/health/health.service';
 
 // Export module
 export * from './microsoft-outlook.module';
@@ -30,6 +31,7 @@ export * from './enums/event-types.enum';
 export * from './enums/show-as-type.enum';
 export * from './enums/microsoft-user-status.enum';
 export * from './enums/microsoft-tenant-status.enum';
+export * from './enums/user-health-status.enum';
 
 // Export constants
 export * from './constants';
@@ -44,10 +46,12 @@ export * from './controllers/calendar.controller';
 export * from './controllers/microsoft-auth.controller';
 export * from './controllers/tenant-auth.controller';
 export * from './controllers/email.controller';
+export * from './controllers/health.controller';
 
 // Export DTOs
 export * from './dto/outlook-webhook-notification.dto';
 export * from './dto/bulk-connect-users.dto';
+export * from './dto/health-check.dto';
 
 // Entities
 export * from './entities/outlook-webhook-subscription.entity';

--- a/src/microsoft-outlook.module.ts
+++ b/src/microsoft-outlook.module.ts
@@ -6,6 +6,7 @@ import { MicrosoftAuthService } from "./services/auth/microsoft-auth.service";
 import { AppOnlyAuthService } from "./services/auth/app-only-auth.service";
 import { MicrosoftAuthController } from "./controllers/microsoft-auth.controller";
 import { TenantAuthController } from "./controllers/tenant-auth.controller";
+import { HealthController } from "./controllers/health.controller";
 import { CalendarController } from "./controllers/calendar.controller";
 import { EmailController } from "./controllers/email.controller";
 import { OutlookWebhookSubscription } from "./entities/outlook-webhook-subscription.entity";
@@ -44,6 +45,7 @@ import { WebhookClientStateGuard } from "./guards/webhook-client-state.guard";
 import { TenantCalendarService } from "./services/tenant/tenant-calendar.service";
 import { TenantUserService } from "./services/tenant/tenant-user.service";
 import { TenantProvisioningService } from "./services/tenant/tenant-provisioning.service";
+import { HealthService } from "./services/health/health.service";
 import { MicrosoftTenantRepository } from "./repositories/microsoft-tenant.repository";
 
 export const { ConfigurableModuleClass, MODULE_OPTIONS_TOKEN } =
@@ -139,6 +141,7 @@ async function buildRateLimitStore(
   controllers: [
     MicrosoftAuthController,
     TenantAuthController,
+    HealthController,
     CalendarController,
     EmailController,
   ],
@@ -177,6 +180,7 @@ async function buildRateLimitStore(
     TenantCalendarService,
     TenantUserService,
     TenantProvisioningService,
+    HealthService,
     MicrosoftTenantRepository,
   ],
   exports: [
@@ -197,6 +201,7 @@ async function buildRateLimitStore(
     TenantCalendarService,
     TenantUserService,
     TenantProvisioningService,
+    HealthService,
     MicrosoftTenantRepository,
   ],
 })

--- a/src/microsoft-outlook.module.ts
+++ b/src/microsoft-outlook.module.ts
@@ -43,6 +43,7 @@ import {
 import { WebhookClientStateGuard } from "./guards/webhook-client-state.guard";
 import { TenantCalendarService } from "./services/tenant/tenant-calendar.service";
 import { TenantUserService } from "./services/tenant/tenant-user.service";
+import { TenantProvisioningService } from "./services/tenant/tenant-provisioning.service";
 import { MicrosoftTenantRepository } from "./repositories/microsoft-tenant.repository";
 
 export const { ConfigurableModuleClass, MODULE_OPTIONS_TOKEN } =
@@ -175,6 +176,7 @@ async function buildRateLimitStore(
     // Tenant services for app-only authentication
     TenantCalendarService,
     TenantUserService,
+    TenantProvisioningService,
     MicrosoftTenantRepository,
   ],
   exports: [
@@ -194,6 +196,7 @@ async function buildRateLimitStore(
     // Tenant services for app-only authentication
     TenantCalendarService,
     TenantUserService,
+    TenantProvisioningService,
     MicrosoftTenantRepository,
   ],
 })

--- a/src/mock/chaos/chaos-db.ts
+++ b/src/mock/chaos/chaos-db.ts
@@ -1,0 +1,293 @@
+import { FindOperator } from 'typeorm';
+import { MicrosoftUser } from '../../entities/microsoft-user.entity';
+import { MicrosoftTenant } from '../../entities/microsoft-tenant.entity';
+import { MicrosoftTenantStatus } from '../../enums/microsoft-tenant-status.enum';
+import { OutlookWebhookSubscription } from '../../entities/outlook-webhook-subscription.entity';
+import { ChaosEngine, chaosDelay } from './chaos-engine';
+import { ChaosMetrics } from './chaos-metrics';
+
+/**
+ * In-memory database behind the repository fakes.
+ *
+ * The fakes mirror the REAL repositories' query semantics (active flags, `expirationDateTime >
+ * now` filters, upsert-by-subscriptionId, the query-builder shapes used by
+ * `clearTenantUserMappings`) so chaos tests exercise genuine behaviour, not mock behaviour.
+ * Every method can be disrupted through the shared {@link ChaosEngine} using `db.<method>`
+ * routes, plus a table-wide latency range (virtual time under fake timers).
+ */
+export class ChaosDb {
+  readonly users: MicrosoftUser[] = [];
+  readonly tenants: MicrosoftTenant[] = [];
+  readonly subscriptions: OutlookWebhookSubscription[] = [];
+  private userSeq = 0;
+  private tenantSeq = 0;
+  private subSeq = 0;
+
+  constructor(
+    private readonly engine: ChaosEngine,
+    private readonly metrics: ChaosMetrics,
+    private readonly latencyMs: { min: number; max: number } = { min: 0, max: 0 },
+  ) {}
+
+  /** Latency + planned-failure hook wrapped around every repo method. */
+  private async touch(method: string, key: string): Promise<void> {
+    this.metrics.recordDb(method);
+    if (this.latencyMs.max > 0) {
+      await chaosDelay(this.engine.random.int(this.latencyMs.min, this.latencyMs.max));
+    }
+    const injected = this.engine.decide(`db.${method}`, key, { plansOnly: true });
+    if (injected) {
+      this.metrics.recordInjected(`db.${method}`, injected.response?.status ?? 'network');
+      throw new Error(`chaos db failure on ${method} (${key})`);
+    }
+  }
+
+  // ── seeding ─────────────────────────────────────────────────────────
+
+  addTenant(partial: Partial<MicrosoftTenant>): MicrosoftTenant {
+    this.tenantSeq += 1;
+    const tenant = Object.assign(new MicrosoftTenant(), { id: this.tenantSeq, isActive: true }, partial);
+    this.tenants.push(tenant);
+    return tenant;
+  }
+
+  addUser(partial: Partial<MicrosoftUser>): MicrosoftUser {
+    this.userSeq += 1;
+    const user = Object.assign(new MicrosoftUser(), { id: this.userSeq }, partial);
+    this.users.push(user);
+    return user;
+  }
+
+  addSubscription(partial: Partial<OutlookWebhookSubscription>): OutlookWebhookSubscription {
+    this.subSeq += 1;
+    const sub = Object.assign(new OutlookWebhookSubscription(), { id: this.subSeq, isActive: true }, partial);
+    this.subscriptions.push(sub);
+    return sub;
+  }
+
+  activeSubsOfUser(userId: number): OutlookWebhookSubscription[] {
+    return this.subscriptions.filter((s) => s.userId === userId && s.isActive);
+  }
+
+  // ── fakes ───────────────────────────────────────────────────────────
+
+  /** Structural stand-in for `OutlookWebhookSubscriptionRepository` (real query semantics). */
+  buildSubscriptionRepo() {
+    const now = (): number => Date.now();
+    return {
+      saveSubscription: async (partial: Partial<OutlookWebhookSubscription>) => {
+        // Chaos key by externalUserId so tests can plan failures deterministically
+        // (internal ids depend on async creation order under concurrency).
+        const owner = this.users.find((u) => u.id === partial.userId);
+        await this.touch('subs.save', owner?.externalUserId ?? String(partial.userId ?? '?'));
+        const existing = this.subscriptions.find((s) => s.subscriptionId === partial.subscriptionId);
+        if (existing) {
+          Object.assign(existing, partial, { id: existing.id });
+          return existing;
+        }
+        return this.addSubscription(partial);
+      },
+      findAllActiveByUserId: async (userId: number) => {
+        await this.touch('subs.findAllActiveByUserId', String(userId));
+        return this.subscriptions.filter((s) => s.userId === userId && s.isActive);
+      },
+      findActiveByUserId: async (userId: number) => {
+        await this.touch('subs.findActiveByUserId', String(userId));
+        return this.subscriptions.find((s) => s.userId === userId && s.isActive) ?? null;
+      },
+      findActiveByUserIds: async (userIds: number[]) => {
+        await this.touch('subs.findActiveByUserIds', String(userIds.length));
+        const ids = new Set(userIds);
+        // Mirrors the real repository: active AND not expired.
+        return this.subscriptions.filter(
+          (s) => ids.has(s.userId) && s.isActive && s.expirationDateTime.getTime() > now(),
+        );
+      },
+      findAllActiveByTenantId: async (tenantId: string) => {
+        await this.touch('subs.findAllActiveByTenantId', tenantId);
+        return this.subscriptions.filter(
+          (s) => s.tenantId === tenantId && s.isActive && s.expirationDateTime.getTime() > now(),
+        );
+      },
+      findActiveByTenantAndMicrosoftUser: async (tenantId: string, microsoftUserId: string) => {
+        await this.touch('subs.findActiveByTenantAndMicrosoftUser', microsoftUserId);
+        return (
+          this.subscriptions.find(
+            (s) =>
+              s.tenantId === tenantId &&
+              s.microsoftUserId === microsoftUserId &&
+              s.isActive &&
+              s.expirationDateTime.getTime() > now(),
+          ) ?? null
+        );
+      },
+      deactivateSubscription: async (subscriptionId: string) => {
+        await this.touch('subs.deactivate', subscriptionId);
+        const sub = this.subscriptions.find((s) => s.subscriptionId === subscriptionId);
+        if (sub) sub.isActive = false;
+      },
+      deactivateAllByTenantId: async (tenantId: string) => {
+        await this.touch('subs.deactivateAllByTenantId', tenantId);
+        let affected = 0;
+        for (const sub of this.subscriptions) {
+          if (sub.tenantId === tenantId && sub.isActive) {
+            sub.isActive = false;
+            affected += 1;
+          }
+        }
+        return affected;
+      },
+    };
+  }
+
+  /** Structural stand-in for the TypeORM `Repository<MicrosoftUser>` subset the services use. */
+  buildUserOrmRepo() {
+    const matches = (user: MicrosoftUser, where: Record<string, unknown>): boolean => {
+      for (const [field, expected] of Object.entries(where)) {
+        const actual = (user as unknown as Record<string, unknown>)[field];
+        if (expected instanceof FindOperator) {
+          if (expected.type === 'in') {
+            const values = expected.value as unknown as unknown[];
+            if (!values.includes(actual)) return false;
+          } else {
+            throw new Error(`ChaosDb: unsupported FindOperator ${expected.type}`);
+          }
+        } else if (actual !== expected) {
+          return false;
+        }
+      }
+      return true;
+    };
+
+    // Reads return SHALLOW CLONES, mirroring a real ORM: mutating a loaded entity must not
+    // change the database until save() is called. (Handing out live table references would
+    // silently persist mutations even when the save is chaos-failed.)
+    const clone = (user: MicrosoftUser): MicrosoftUser => Object.assign(new MicrosoftUser(), user);
+
+    return {
+      find: async (options: { where: Record<string, unknown> }) => {
+        await this.touch('users.find', JSON.stringify(Object.keys(options.where)));
+        return this.users.filter((u) => matches(u, options.where)).map(clone);
+      },
+      findOne: async (options: { where: Record<string, unknown> }) => {
+        await this.touch('users.findOne', String(options.where.externalUserId ?? options.where.id ?? '?'));
+        const row = this.users.find((u) => matches(u, options.where));
+        return row ? clone(row) : null;
+      },
+      save: async (user: MicrosoftUser) => {
+        await this.touch('users.save', user.externalUserId);
+        const existing = this.users.find((u) => u.externalUserId === user.externalUserId);
+        if (existing) {
+          Object.assign(existing, user, { id: existing.id });
+          return clone(existing);
+        }
+        return clone(this.addUser(Object.assign(new MicrosoftUser(), user)));
+      },
+      createQueryBuilder: (_alias?: string) => this.buildUserQueryBuilder(),
+    };
+  }
+
+  /**
+   * Interprets the exact query-builder shapes `clearTenantUserMappings` issues:
+   * select refresh tokens / bulk unmap UPDATE / bulk DELETE, filtered by `tenant_id = :id`
+   * and `refresh_token IS [NOT] NULL`.
+   */
+  private buildUserQueryBuilder() {
+    let tenantInternalId: number | null = null;
+    let refreshTokenFilter: 'not-null' | 'null' | null = null;
+    let operation: 'select' | 'update' | 'delete' = 'select';
+    let setPayload: Partial<MicrosoftUser> | null = null;
+
+    const applyWhere = (clause: string, params?: Record<string, unknown>): void => {
+      if (clause.includes('tenant_id = :id')) tenantInternalId = Number(params?.id);
+      else if (clause.includes('refresh_token IS NOT NULL')) refreshTokenFilter = 'not-null';
+      else if (clause.includes('refresh_token IS NULL')) refreshTokenFilter = 'null';
+      else throw new Error(`ChaosDb: unsupported where clause "${clause}"`);
+    };
+
+    const selectRows = (): MicrosoftUser[] =>
+      this.users.filter((u) => {
+        if (u.tenant?.id !== tenantInternalId) return false;
+        if (refreshTokenFilter === 'not-null') return u.refreshToken !== null;
+        if (refreshTokenFilter === 'null') return u.refreshToken === null;
+        return true;
+      });
+
+    const qb = {
+      select: (_field: string, _aliasName: string) => qb,
+      where: (clause: string, params?: Record<string, unknown>) => {
+        applyWhere(clause, params);
+        return qb;
+      },
+      andWhere: (clause: string, params?: Record<string, unknown>) => {
+        applyWhere(clause, params);
+        return qb;
+      },
+      update: () => {
+        operation = 'update';
+        return qb;
+      },
+      delete: () => {
+        operation = 'delete';
+        return qb;
+      },
+      set: (payload: Partial<MicrosoftUser>) => {
+        setPayload = payload;
+        return qb;
+      },
+      getRawMany: async <T>(): Promise<T[]> => {
+        await this.touch('users.qb.select', String(tenantInternalId));
+        return selectRows().map((u) => ({ refreshToken: u.refreshToken }) as T);
+      },
+      execute: async (): Promise<{ affected: number }> => {
+        await this.touch(`users.qb.${operation}`, String(tenantInternalId));
+        const rows = selectRows();
+        if (operation === 'update' && setPayload) {
+          for (const row of rows) Object.assign(row, setPayload);
+        } else if (operation === 'delete') {
+          for (const row of rows) this.users.splice(this.users.indexOf(row), 1);
+        }
+        return { affected: rows.length };
+      },
+    };
+    return qb;
+  }
+
+  /** Structural stand-in for the TypeORM `Repository<MicrosoftTenant>` subset. */
+  buildTenantOrmRepo() {
+    return {
+      findOne: async (options: { where: { tenantId: string; isActive?: boolean } }) => {
+        await this.touch('tenants.findOne', options.where.tenantId);
+        return (
+          this.tenants.find(
+            (t) =>
+              t.tenantId === options.where.tenantId &&
+              (options.where.isActive === undefined || t.isActive === options.where.isActive),
+          ) ?? null
+        );
+      },
+    };
+  }
+
+  /** Structural stand-in for the custom `MicrosoftTenantRepository` (connection repo). */
+  buildTenantConnectionRepo() {
+    return {
+      findByTenantId: async (tenantId: string) => {
+        await this.touch('tenants.findByTenantId', tenantId);
+        // Mirrors the real repository: only active connections are returned.
+        return this.tenants.find((t) => t.tenantId === tenantId && t.isActive) ?? null;
+      },
+      findAllActive: async () => {
+        await this.touch('tenants.findAllActive', '*');
+        // Mirrors the real repository: isActive AND status === ACTIVE.
+        return this.tenants.filter((t) => t.isActive && t.status === MicrosoftTenantStatus.ACTIVE);
+      },
+      deactivate: async (tenantId: string) => {
+        await this.touch('tenants.deactivate', tenantId);
+        const tenant = this.tenants.find((t) => t.tenantId === tenantId);
+        if (tenant) tenant.isActive = false;
+        this.metrics.mark('tenant:deactivate');
+      },
+    };
+  }
+}

--- a/src/mock/chaos/chaos-engine.ts
+++ b/src/mock/chaos/chaos-engine.ts
@@ -1,0 +1,164 @@
+import { SeededRandom } from './seeded-random';
+
+/** Random disruption probabilities applied per Graph attempt (0 disables a category). */
+export interface ChaosRates {
+  /** 429 Too Many Requests with Retry-After header (retryable; costs ≥5s virtual backoff). */
+  throttle429?: number;
+  /** 503 Service Unavailable with Retry-After (retryable). */
+  unavailable503?: number;
+  /** 500 Internal Server Error (retryable via exponential backoff). */
+  serverError500?: number;
+  /** ECONNRESET-style network error (retryable). */
+  networkError?: number;
+}
+
+/** A planned, deterministic failure targeting one logical key on one route. */
+interface PlanEntry {
+  status: number | 'network';
+  /** 'always' keeps failing forever; a number fails that many times then succeeds. */
+  remaining: number | 'always';
+  /**
+   * false (default): fail BEFORE the state mutation (at-most-once — request never reached Graph).
+   * true: fail AFTER the mutation (at-least-once — Graph applied the change, the response was
+   * lost). The second models the nastier real-world failure: a retried non-idempotent request.
+   */
+  afterExecute: boolean;
+}
+
+/** A chaos decision: the error to inject and whether it fires before or after the mutation. */
+export interface ChaosDecision {
+  error: ChaosHttpError;
+  afterExecute: boolean;
+}
+
+/** An axios-shaped error the module's retry classifiers understand. */
+export interface ChaosHttpError extends Error {
+  isAxiosError: boolean;
+  code?: string;
+  response?: {
+    status: number;
+    headers: Record<string, string>;
+    data: unknown;
+  };
+}
+
+/** Build an axios-shaped HTTP error for a status (or a network error). */
+export function buildChaosError(status: number | 'network'): ChaosHttpError {
+  if (status === 'network') {
+    const err = new Error('chaos: socket hang up') as ChaosHttpError;
+    err.isAxiosError = true;
+    err.code = 'ECONNRESET';
+    return err;
+  }
+  const err = new Error(`chaos: HTTP ${status}`) as ChaosHttpError;
+  err.isAxiosError = true;
+  err.response = {
+    status,
+    // Retry-After present on throttle/unavailable; the module clamps it to >= 5s,
+    // which shows up as *virtual* backoff time under fake timers.
+    headers: status === 429 || status === 503 ? { 'retry-after': '0' } : {},
+    data: { error: { code: `chaos_${status}`, message: `injected ${status}` } },
+  };
+  return err;
+}
+
+/**
+ * Seeded chaos decision engine shared by the Graph and DB fakes.
+ *
+ * Two disruption modes compose:
+ * - **Plans** (deterministic): `alwaysFail`/`failTimes` target a specific `(route, key)` so a
+ *   test can compute exact expected outcomes (e.g. "exactly these 15 users fail").
+ * - **Rates** (randomized but seeded): per-attempt probabilities of 429/503/500/network, for
+ *   robustness runs where assertions are conservation laws and ceilings, not exact values.
+ *
+ * Plans are consulted before rates, so planned outcomes stay deterministic even in a storm.
+ */
+export class ChaosEngine {
+  readonly random: SeededRandom;
+  private readonly plans = new Map<string, PlanEntry>();
+
+  constructor(
+    seed: number,
+    private rates: ChaosRates = {},
+    private readonly latencyMs: { min: number; max: number } = { min: 0, max: 0 },
+  ) {
+    this.random = new SeededRandom(seed);
+  }
+
+  /** Change the random disruption rates mid-test (e.g. "the weather clears" for a rerun). */
+  setRates(rates: ChaosRates): void {
+    this.rates = rates;
+  }
+
+  private planKey(route: string, key: string): string {
+    return `${route}|${key}`;
+  }
+
+  /** Fail every attempt for (route, key) with the given status — before the state mutation. */
+  alwaysFail(route: string, key: string, status: number | 'network'): void {
+    this.plans.set(this.planKey(route, key), { status, remaining: 'always', afterExecute: false });
+  }
+
+  /** Fail the first `times` attempts for (route, key), then let it succeed. */
+  failTimes(route: string, key: string, times: number, status: number | 'network'): void {
+    this.plans.set(this.planKey(route, key), { status, remaining: times, afterExecute: false });
+  }
+
+  /**
+   * Fail the first `times` attempts AFTER the state mutation has been applied — the request
+   * reached Graph and took effect, but the response was lost (at-least-once semantics). A
+   * retried non-idempotent request (e.g. POST /subscriptions) then duplicates the mutation.
+   */
+  failTimesAfterExecute(route: string, key: string, times: number, status: number | 'network'): void {
+    this.plans.set(this.planKey(route, key), { status, remaining: times, afterExecute: true });
+  }
+
+  /**
+   * Decide the fate of one attempt. Returns the decision, or null to let it through untouched.
+   * `plansOnly` skips the random rates — used by the DB fakes, where random disruption would
+   * make planned outcomes nondeterministic (DB failures are always plan-targeted).
+   *
+   * A key whose `failTimes` plan is exhausted is FORCED to succeed (random rates are skipped),
+   * so planned outcomes stay deterministic even inside a random storm.
+   */
+  decideFull(route: string, key: string, opts?: { plansOnly?: boolean }): ChaosDecision | null {
+    const plan = this.plans.get(this.planKey(route, key));
+    if (plan) {
+      if (plan.remaining === 'always') {
+        return { error: buildChaosError(plan.status), afterExecute: plan.afterExecute };
+      }
+      if (plan.remaining > 0) {
+        plan.remaining -= 1;
+        return { error: buildChaosError(plan.status), afterExecute: plan.afterExecute };
+      }
+      return null; // exhausted plan → forced success, immune to the random weather
+    }
+    if (opts?.plansOnly) return null;
+
+    if (this.random.chance(this.rates.throttle429 ?? 0)) return { error: buildChaosError(429), afterExecute: false };
+    if (this.random.chance(this.rates.unavailable503 ?? 0))
+      return { error: buildChaosError(503), afterExecute: false };
+    if (this.random.chance(this.rates.serverError500 ?? 0))
+      return { error: buildChaosError(500), afterExecute: false };
+    if (this.random.chance(this.rates.networkError ?? 0))
+      return { error: buildChaosError('network'), afterExecute: false };
+    return null;
+  }
+
+  /** Back-compat convenience: the injected error only (before-mutation), or null. */
+  decide(route: string, key: string, opts?: { plansOnly?: boolean }): ChaosHttpError | null {
+    return this.decideFull(route, key, opts)?.error ?? null;
+  }
+
+  /** Sampled latency for one call (milliseconds of *virtual* time under fake timers). */
+  latency(): number {
+    if (this.latencyMs.max <= 0) return 0;
+    return this.random.int(this.latencyMs.min, this.latencyMs.max);
+  }
+}
+
+/** setTimeout-based delay — under jest fake timers this costs virtual, not real, time. */
+export function chaosDelay(ms: number): Promise<void> {
+  if (ms <= 0) return Promise.resolve();
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/src/mock/chaos/chaos-graph.ts
+++ b/src/mock/chaos/chaos-graph.ts
@@ -1,0 +1,303 @@
+import { ChaosEngine, chaosDelay, buildChaosError } from './chaos-engine';
+import { ChaosMetrics } from './chaos-metrics';
+
+/** A Microsoft user living in the fake Graph directory. */
+export interface GraphUser {
+  id: string;
+  userPrincipalName: string;
+  displayName: string;
+  mail: string | null;
+}
+
+/** A webhook subscription living in the fake Graph. */
+export interface GraphSubscription {
+  id: string;
+  resource: string;
+  changeType: string;
+  clientState: string;
+  notificationUrl: string;
+  expirationDateTime: string;
+}
+
+interface GraphResponse {
+  status: number;
+  data: unknown;
+}
+
+interface BatchInnerRequest {
+  id: string;
+  method: string;
+  url: string;
+}
+
+/** Minimal structural view of a jest-mocked axios module (avoids importing jest types). */
+export interface AxiosMockLike {
+  get: { mockImplementation: (impl: (url: string, config?: unknown) => Promise<unknown>) => unknown };
+  post: {
+    mockImplementation: (impl: (url: string, body?: unknown, config?: unknown) => Promise<unknown>) => unknown;
+  };
+  delete: { mockImplementation: (impl: (url: string, config?: unknown) => Promise<unknown>) => unknown };
+  patch: {
+    mockImplementation: (impl: (url: string, body?: unknown, config?: unknown) => Promise<unknown>) => unknown;
+  };
+  isAxiosError: { mockImplementation: (impl: (err: unknown) => boolean) => unknown };
+}
+
+/**
+ * Chaos route names — targets for {@link ChaosEngine.alwaysFail}/`failTimes` plans and for
+ * metrics assertions.
+ *
+ * - `users.lookup` (key = email) — GET /users?$filter
+ * - `users.get` (key = upn) — GET /users/{upn}
+ * - `subs.create` (key = msUserId or `me:{internalId}`) — POST /subscriptions
+ * - `subs.delete` / `subs.get` (key = subscriptionId)
+ * - `batch` (key = `*`, whole call) and `batch.item` (key = subscriptionId, per inner request)
+ * - `auth.revoke` (key = refresh token) — POST …/logout
+ */
+export type GraphRoute =
+  | 'users.lookup'
+  | 'users.get'
+  | 'subs.create'
+  | 'subs.delete'
+  | 'subs.get'
+  | 'subs.list'
+  | 'subs.patch'
+  | 'batch'
+  | 'batch.item'
+  | 'auth.revoke';
+
+/**
+ * A stateful in-memory Microsoft Graph behind a chaos layer.
+ *
+ * The services under test call the (jest-mocked) `axios` module; `install()` routes those calls
+ * here. Each attempt pays a sampled latency (virtual time under fake timers), may be disrupted
+ * by the {@link ChaosEngine} (plans first, then random rates), and is recorded in
+ * {@link ChaosMetrics} — so flows behave *functionally* like real Graph (create returns an id
+ * that later GET/DELETE resolve; $batch fans out per item) while tests control the weather.
+ */
+export class ChaosGraph {
+  readonly users = new Map<string, GraphUser>(); // keyed by lower-cased email/UPN
+  readonly subscriptions = new Map<string, GraphSubscription>();
+  private seq = 0;
+
+  constructor(
+    readonly engine: ChaosEngine,
+    readonly metrics: ChaosMetrics,
+  ) {}
+
+  seedUser(email: string, msUserId: string): GraphUser {
+    const user: GraphUser = {
+      id: msUserId,
+      userPrincipalName: email,
+      displayName: email.split('@')[0],
+      mail: email,
+    };
+    this.users.set(email.toLowerCase(), user);
+    return user;
+  }
+
+  seedSubscription(sub: Omit<GraphSubscription, 'expirationDateTime'> & { expirationDateTime?: string }): void {
+    this.subscriptions.set(sub.id, {
+      ...sub,
+      expirationDateTime: sub.expirationDateTime ?? new Date(Date.now() + 72 * 3600 * 1000).toISOString(),
+    });
+  }
+
+  subscriptionIdsForResourcePrefix(prefix: string): string[] {
+    return [...this.subscriptions.values()].filter((s) => s.resource.startsWith(prefix)).map((s) => s.id);
+  }
+
+  /**
+   * Point of entry for every faked axios call. Resolves a response or throws an axios-shaped
+   * error.
+   *
+   * Failure semantics: random-rate and default plan injections fire BEFORE `execute()` — the
+   * request never reaches Graph (at-most-once). Plans registered via `failTimesAfterExecute`
+   * fire AFTER `execute()` mutated state — the request took effect but the response was lost
+   * (at-least-once), which is how a retried non-idempotent create duplicates a subscription.
+   */
+  private async dispatch(
+    route: GraphRoute,
+    key: string,
+    execute: () => GraphResponse,
+  ): Promise<GraphResponse> {
+    this.metrics.enter(route, key);
+    try {
+      await chaosDelay(this.engine.latency());
+      const decision = this.engine.decideFull(route, key);
+      if (decision && !decision.afterExecute) {
+        this.metrics.recordInjected(route, decision.error.response?.status ?? 'network');
+        throw decision.error;
+      }
+      const result = execute();
+      if (decision?.afterExecute) {
+        // State IS mutated — the caller just never learns about it.
+        this.metrics.recordInjected(route, decision.error.response?.status ?? 'network');
+        throw decision.error;
+      }
+      if (result.status >= 400) {
+        throw buildChaosError(result.status);
+      }
+      return result;
+    } finally {
+      this.metrics.exit();
+    }
+  }
+
+  // ── route handlers ──────────────────────────────────────────────────
+
+  private handleUsersLookup(params: Record<string, unknown> | undefined): Promise<GraphResponse> {
+    const filter = String(params?.['$filter'] ?? '');
+    const match = /'([^']*)'/.exec(filter);
+    const email = (match?.[1] ?? '').toLowerCase();
+    return this.dispatch('users.lookup', email, () => {
+      const user = this.users.get(email);
+      return { status: 200, data: { value: user ? [user] : [] } };
+    });
+  }
+
+  private handleUsersGet(upn: string): Promise<GraphResponse> {
+    const key = decodeURIComponent(upn).toLowerCase();
+    return this.dispatch('users.get', key, () => {
+      const user = this.users.get(key);
+      return user ? { status: 200, data: user } : { status: 404, data: null };
+    });
+  }
+
+  private handleSubsCreate(body: Record<string, unknown>): Promise<GraphResponse> {
+    const resource = String(body.resource ?? '');
+    const clientState = String(body.clientState ?? '');
+    // Plan key: app-only → the Microsoft user id in the resource; delegated → `me:{internalId}`.
+    const appOnlyMatch = /^\/users\/([^/]+)\/events$/.exec(resource);
+    const delegatedMatch = /^user_(\d+)_/.exec(clientState);
+    const key = appOnlyMatch ? appOnlyMatch[1] : `me:${delegatedMatch?.[1] ?? 'unknown'}`;
+
+    return this.dispatch('subs.create', key, () => {
+      this.seq += 1;
+      const sub: GraphSubscription = {
+        id: `graph-sub-${this.seq}`,
+        resource,
+        changeType: String(body.changeType ?? 'created,updated,deleted'),
+        clientState,
+        notificationUrl: String(body.notificationUrl ?? ''),
+        expirationDateTime: String(body.expirationDateTime ?? new Date().toISOString()),
+      };
+      this.subscriptions.set(sub.id, sub);
+      return { status: 201, data: sub };
+    });
+  }
+
+  private handleSubsDelete(id: string): Promise<GraphResponse> {
+    return this.dispatch('subs.delete', id, () => {
+      if (!this.subscriptions.has(id)) return { status: 404, data: null };
+      this.subscriptions.delete(id);
+      return { status: 204, data: '' };
+    });
+  }
+
+  private handleSubsGet(id: string): Promise<GraphResponse> {
+    return this.dispatch('subs.get', id, () => {
+      const sub = this.subscriptions.get(id);
+      return sub ? { status: 200, data: sub } : { status: 404, data: null };
+    });
+  }
+
+  private handleSubsList(): Promise<GraphResponse> {
+    return this.dispatch('subs.list', '*', () => ({
+      status: 200,
+      data: { value: [...this.subscriptions.values()] },
+    }));
+  }
+
+  private async handleBatch(body: { requests?: BatchInnerRequest[] }): Promise<GraphResponse> {
+    // The outer $batch call is one HTTP request (chaos-able as a whole)…
+    return this.dispatch('batch', '*', () => ({ status: 200, data: null })).then(async () => {
+      // …then each inner request gets its own per-item chaos decision.
+      const responses: { id: string; status: number; body: unknown }[] = [];
+      for (const request of body.requests ?? []) {
+        const idMatch = /\/subscriptions\/([^/?]+)/.exec(request.url);
+        const subId = idMatch?.[1] ?? 'unknown';
+        const injected = this.engine.decide('batch.item', subId);
+        if (injected) {
+          this.metrics.recordInjected('batch.item', injected.response?.status ?? 'network');
+          responses.push({
+            id: request.id,
+            status: injected.response?.status ?? 500,
+            body: injected.response?.data ?? null,
+          });
+          continue;
+        }
+        if (request.method === 'DELETE') {
+          if (this.subscriptions.has(subId)) {
+            this.subscriptions.delete(subId);
+            responses.push({ id: request.id, status: 204, body: null });
+          } else {
+            responses.push({ id: request.id, status: 404, body: null });
+          }
+        } else if (request.method === 'GET') {
+          const sub = this.subscriptions.get(subId);
+          responses.push({ id: request.id, status: sub ? 200 : 404, body: sub ?? null });
+        } else {
+          responses.push({ id: request.id, status: 400, body: null });
+        }
+      }
+      return { status: 200, data: { responses } };
+    });
+  }
+
+  private handleRevoke(body: unknown): Promise<GraphResponse> {
+    const token = body instanceof URLSearchParams ? (body.get('token') ?? 'unknown') : 'unknown';
+    return this.dispatch('auth.revoke', token, () => ({ status: 200, data: {} }));
+  }
+
+  private handleSubsPatch(id: string, body: Record<string, unknown>): Promise<GraphResponse> {
+    return this.dispatch('subs.patch', id, () => {
+      const sub = this.subscriptions.get(id);
+      if (!sub) return { status: 404, data: null };
+      if (typeof body.expirationDateTime === 'string') {
+        sub.expirationDateTime = body.expirationDateTime;
+      }
+      return { status: 200, data: sub };
+    });
+  }
+
+  // ── axios wiring ───────────────────────────────────────────────────
+
+  /** Route the jest-mocked axios methods into this fake Graph. */
+  install(mockedAxios: AxiosMockLike): void {
+    mockedAxios.isAxiosError.mockImplementation(
+      (err: unknown): boolean =>
+        typeof err === 'object' && err !== null && (err as { isAxiosError?: boolean }).isAxiosError === true,
+    );
+
+    mockedAxios.get.mockImplementation(async (url: string, config?: unknown) => {
+      const params = (config as { params?: Record<string, unknown> } | undefined)?.params;
+      const subMatch = /\/v1\.0\/subscriptions\/([^/?]+)/.exec(url);
+      if (subMatch) return this.handleSubsGet(subMatch[1]);
+      if (/\/v1\.0\/subscriptions\/?$/.test(url)) return this.handleSubsList();
+      const userMatch = /\/v1\.0\/users\/([^/?]+)/.exec(url);
+      if (userMatch) return this.handleUsersGet(userMatch[1]);
+      if (/\/v1\.0\/users\/?$/.test(url)) return this.handleUsersLookup(params);
+      throw new Error(`ChaosGraph: unhandled GET ${url}`);
+    });
+
+    mockedAxios.post.mockImplementation(async (url: string, body?: unknown) => {
+      if (url.includes('/$batch')) return this.handleBatch(body as { requests?: BatchInnerRequest[] });
+      if (/\/v1\.0\/subscriptions\/?$/.test(url)) return this.handleSubsCreate(body as Record<string, unknown>);
+      if (url.includes('/logout')) return this.handleRevoke(body);
+      throw new Error(`ChaosGraph: unhandled POST ${url}`);
+    });
+
+    mockedAxios.delete.mockImplementation(async (url: string) => {
+      const subMatch = /\/v1\.0\/subscriptions\/([^/?]+)/.exec(url);
+      if (subMatch) return this.handleSubsDelete(subMatch[1]);
+      throw new Error(`ChaosGraph: unhandled DELETE ${url}`);
+    });
+
+    mockedAxios.patch.mockImplementation(async (url: string, body?: unknown) => {
+      const subMatch = /\/v1\.0\/subscriptions\/([^/?]+)/.exec(url);
+      if (subMatch) return this.handleSubsPatch(subMatch[1], (body ?? {}) as Record<string, unknown>);
+      throw new Error(`ChaosGraph: unhandled PATCH ${url}`);
+    });
+  }
+}

--- a/src/mock/chaos/chaos-metrics.ts
+++ b/src/mock/chaos/chaos-metrics.ts
@@ -1,0 +1,109 @@
+/**
+ * Consumption/behaviour metrics collected by the chaos fakes.
+ *
+ * Everything is count- or ordering-based (robust in CI); wall-clock numbers are reported for
+ * visibility but never asserted. "Virtual" time is jest fake-timer time — what the flow *would*
+ * have waited on latency and retry backoff in production.
+ */
+export class ChaosMetrics {
+  /** Attempts per route (each retry counts — attempts − logical ops = retries). */
+  readonly attempts = new Map<string, number>();
+  /** Injected errors per `route|status`. */
+  readonly injected = new Map<string, number>();
+  /** Attempts per `route|key` — lets tests assert exact retry counts for planned keys. */
+  readonly perKeyAttempts = new Map<string, number>();
+  /** DB fake calls per method name. */
+  readonly dbCalls = new Map<string, number>();
+  /** Ordered trace of notable operations (graph routes, db writes, lifecycle steps). */
+  readonly timeline: string[] = [];
+
+  private inFlight = 0;
+  peakInFlight = 0;
+
+  private readonly startedRealMs = performance.now();
+  private readonly startedVirtualMs = Date.now();
+  private readonly startedHeap = process.memoryUsage().heapUsed;
+
+  private bump(map: Map<string, number>, key: string): void {
+    map.set(key, (map.get(key) ?? 0) + 1);
+  }
+
+  enter(route: string, key: string): void {
+    this.inFlight += 1;
+    this.peakInFlight = Math.max(this.peakInFlight, this.inFlight);
+    this.bump(this.attempts, route);
+    this.bump(this.perKeyAttempts, `${route}|${key}`);
+    this.timeline.push(`graph:${route}`);
+  }
+
+  exit(): void {
+    this.inFlight -= 1;
+  }
+
+  recordInjected(route: string, status: number | 'network'): void {
+    this.bump(this.injected, `${route}|${status}`);
+  }
+
+  recordDb(method: string): void {
+    this.bump(this.dbCalls, `db.${method}`);
+    this.timeline.push(`db:${method}`);
+  }
+
+  mark(step: string): void {
+    this.timeline.push(step);
+  }
+
+  attemptsFor(route: string): number {
+    return this.attempts.get(route) ?? 0;
+  }
+
+  attemptsForKey(route: string, key: string): number {
+    return this.perKeyAttempts.get(`${route}|${key}`) ?? 0;
+  }
+
+  injectedFor(route: string, status?: number | 'network'): number {
+    if (status !== undefined) return this.injected.get(`${route}|${status}`) ?? 0;
+    let total = 0;
+    for (const [key, count] of this.injected) {
+      if (key.startsWith(`${route}|`)) total += count;
+    }
+    return total;
+  }
+
+  totalInjected(): number {
+    let total = 0;
+    for (const count of this.injected.values()) total += count;
+    return total;
+  }
+
+  dbCallsFor(method: string): number {
+    return this.dbCalls.get(`db.${method}`) ?? 0;
+  }
+
+  /** Index of the last timeline entry matching a prefix (-1 when absent). */
+  lastIndexOf(prefix: string): number {
+    for (let i = this.timeline.length - 1; i >= 0; i--) {
+      if (this.timeline[i].startsWith(prefix)) return i;
+    }
+    return -1;
+  }
+
+  /** Human-readable consumption summary (report-only; never asserted). */
+  report(label: string): string {
+    const realMs = Math.round(performance.now() - this.startedRealMs);
+    const virtualMs = Date.now() - this.startedVirtualMs;
+    const heapMb = (process.memoryUsage().heapUsed - this.startedHeap) / (1024 * 1024);
+
+    const lines: string[] = [
+      `── chaos report: ${label} ──`,
+      `real cpu time      : ${realMs}ms`,
+      `virtual wall-clock : ${virtualMs}ms (latency + retry backoff that production would wait)`,
+      `heap delta         : ${heapMb.toFixed(1)}MB`,
+      `peak graph in-flight: ${this.peakInFlight}`,
+      `graph attempts     : ${[...this.attempts.entries()].map(([r, n]) => `${r}=${n}`).join(', ') || 'none'}`,
+      `injected errors    : ${[...this.injected.entries()].map(([r, n]) => `${r}=${n}`).join(', ') || 'none'}`,
+      `db calls           : ${[...this.dbCalls.entries()].map(([r, n]) => `${r}=${n}`).join(', ') || 'none'}`,
+    ];
+    return lines.join('\n');
+  }
+}

--- a/src/mock/chaos/chaos-world.ts
+++ b/src/mock/chaos/chaos-world.ts
@@ -1,0 +1,293 @@
+import { EventEmitter2 } from '@nestjs/event-emitter';
+import { MicrosoftSubscriptionService } from '../../services/subscription/microsoft-subscription.service';
+import { TenantUserService } from '../../services/tenant/tenant-user.service';
+import { TenantProvisioningService } from '../../services/tenant/tenant-provisioning.service';
+import { HealthService } from '../../services/health/health.service';
+import { TenantAuthController } from '../../controllers/tenant-auth.controller';
+import { HealthController } from '../../controllers/health.controller';
+import { MicrosoftAuthService } from '../../services/auth/microsoft-auth.service';
+import { AppOnlyAuthService } from '../../services/auth/app-only-auth.service';
+import { UserIdConverterService } from '../../services/shared/user-id-converter.service';
+import { GraphRateLimiterService } from '../../services/shared/graph-rate-limiter.service';
+import { OutlookWebhookSubscriptionRepository } from '../../repositories/outlook-webhook-subscription.repository';
+import { MicrosoftTenantRepository } from '../../repositories/microsoft-tenant.repository';
+import { MicrosoftUser } from '../../entities/microsoft-user.entity';
+import { MicrosoftTenant } from '../../entities/microsoft-tenant.entity';
+import { MicrosoftUserStatus } from '../../enums/microsoft-user-status.enum';
+import { MicrosoftTenantStatus } from '../../enums/microsoft-tenant-status.enum';
+import { MicrosoftOutlookConfig } from '../../interfaces/config/outlook-config.interface';
+import { Repository } from 'typeorm';
+import { ChaosEngine, ChaosRates } from './chaos-engine';
+import { ChaosGraph, AxiosMockLike } from './chaos-graph';
+import { ChaosDb } from './chaos-db';
+import { ChaosMetrics } from './chaos-metrics';
+
+/** One user to seed into the world (DB row, Graph directory entry, optional subscription). */
+export interface SeedUser {
+  externalUserId: string;
+  email: string;
+  /**
+   * - `app-only`: mapped into the tenant (microsoftUserId + tenant FK, no delegated tokens)
+   * - `delegated`: delegated tokens only (no tenant mapping)
+   * - `dual`: both capabilities on the row
+   * - `bare`: row exists but has neither (NOT_MAPPED)
+   */
+  kind: 'app-only' | 'delegated' | 'dual' | 'bare';
+  /** false → no microsoft_users row at all (health verdict UNKNOWN). Default true. */
+  inDb?: boolean;
+  /** false → user missing from the Graph directory (lookup misses). Default true. */
+  inGraphDirectory?: boolean;
+  status?: MicrosoftUserStatus;
+  isActive?: boolean;
+  tenantKey?: string;
+  /** Seed an existing calendar subscription for the user. */
+  sub?: {
+    mode: 'app-only' | 'delegated';
+    /** DB expirationDateTime in the past. */
+    expired?: boolean;
+    /** lastNotificationAt long ago (stale). */
+    stale?: boolean;
+    /** false → subscription exists in DB but NOT at Graph (drifted). Default true. */
+    presentAtGraph?: boolean;
+  } | null;
+}
+
+export interface SeedTenant {
+  key: string;
+  tenantId: string;
+  status?: MicrosoftTenantStatus;
+  isActive?: boolean;
+}
+
+export interface WorldOptions {
+  seed: number;
+  tenants?: SeedTenant[];
+  users?: SeedUser[];
+  graphRates?: ChaosRates;
+  graphLatencyMs?: { min: number; max: number };
+  dbLatencyMs?: { min: number; max: number };
+}
+
+export interface CapturedEvent {
+  event: string;
+  payload: unknown;
+}
+
+const HOUR_MS = 3600 * 1000;
+
+/**
+ * Builds a complete chaos world: REAL services (provisioning, subscription, tenant-user,
+ * health) and controllers wired to an in-memory Graph + DB behind a seeded chaos layer.
+ * Only true externals are faked: axios (Microsoft Graph), the TypeORM repositories, and the
+ * token services. Everything in between runs the production code paths.
+ */
+export function buildChaosWorld(mockedAxios: AxiosMockLike, options: WorldOptions) {
+  const metrics = new ChaosMetrics();
+  const engine = new ChaosEngine(options.seed, options.graphRates ?? {}, options.graphLatencyMs ?? { min: 0, max: 0 });
+  const graph = new ChaosGraph(engine, metrics);
+  const db = new ChaosDb(engine, metrics, options.dbLatencyMs ?? { min: 0, max: 0 });
+  graph.install(mockedAxios);
+
+  // ── seed tenants ────────────────────────────────────────────────────
+  const tenantByKey = new Map<string, MicrosoftTenant>();
+  const tenantSeeds = options.tenants ?? [{ key: 'T1', tenantId: 'tenant-t1-guid' }];
+  for (const seed of tenantSeeds) {
+    const tenant = db.addTenant({
+      tenantId: seed.tenantId,
+      status: seed.status ?? MicrosoftTenantStatus.ACTIVE,
+      isActive: seed.isActive ?? true,
+    });
+    tenantByKey.set(seed.key, tenant);
+  }
+  const defaultTenant = tenantByKey.get(tenantSeeds[0].key);
+  if (!defaultTenant) throw new Error('chaos world: no default tenant');
+
+  // ── seed users + subscriptions ──────────────────────────────────────
+  const usersByExternalId = new Map<string, MicrosoftUser>();
+  let seedSubSeq = 0;
+  for (const seed of options.users ?? []) {
+    const tenant = tenantByKey.get(seed.tenantKey ?? tenantSeeds[0].key);
+    if (!tenant) throw new Error(`chaos world: unknown tenantKey for ${seed.externalUserId}`);
+    const msUserId = `ms-${seed.externalUserId}`;
+
+    if (seed.inGraphDirectory !== false) {
+      graph.seedUser(seed.email, msUserId);
+    }
+    if (seed.inDb === false) continue;
+
+    const appOnly = seed.kind === 'app-only' || seed.kind === 'dual';
+    const delegated = seed.kind === 'delegated' || seed.kind === 'dual';
+    const user = db.addUser({
+      externalUserId: seed.externalUserId,
+      isActive: seed.isActive ?? true,
+      status: seed.status ?? MicrosoftUserStatus.ACTIVE,
+      refreshToken: delegated ? `refresh-${seed.externalUserId}` : null,
+      accessToken: delegated ? `access-${seed.externalUserId}` : null,
+      tenant: appOnly ? tenant : null,
+      microsoftUserId: appOnly ? msUserId : null,
+      userPrincipalName: appOnly ? seed.email : null,
+    });
+    usersByExternalId.set(seed.externalUserId, user);
+
+    if (seed.sub) {
+      seedSubSeq += 1;
+      const subscriptionId = `seed-sub-${seedSubSeq}`;
+      const isAppOnlySub = seed.sub.mode === 'app-only';
+      const resource = isAppOnlySub ? `/users/${msUserId}/events` : '/me/events';
+      const now = Date.now();
+      db.addSubscription({
+        subscriptionId,
+        userId: user.id,
+        tenantId: isAppOnlySub ? tenant.tenantId : null,
+        microsoftUserId: isAppOnlySub ? msUserId : null,
+        resource,
+        changeType: 'created,updated,deleted',
+        clientState: isAppOnlySub
+          ? `tenant_${tenant.tenantId}_user_${user.id}_seed`
+          : `user_${user.id}_seed`,
+        notificationUrl: 'https://host.example.com/api/calendar/webhook',
+        expirationDateTime: new Date(seed.sub.expired ? now - 1 * HOUR_MS : now + 48 * HOUR_MS),
+        lastNotificationAt: new Date(seed.sub.stale ? now - 72 * HOUR_MS : now - 1 * HOUR_MS),
+        createdAt: new Date(now - 96 * HOUR_MS),
+      });
+      if (seed.sub.presentAtGraph !== false) {
+        graph.seedSubscription({
+          id: subscriptionId,
+          resource,
+          changeType: 'created,updated,deleted',
+          clientState: 'seeded',
+          notificationUrl: 'https://host.example.com/api/calendar/webhook',
+        });
+      }
+    }
+  }
+
+  // ── fakes for the remaining externals ───────────────────────────────
+  const events: CapturedEvent[] = [];
+  const eventEmitter = {
+    emit: (event: string, payload: unknown): boolean => {
+      events.push({ event, payload });
+      return true;
+    },
+  } as unknown as EventEmitter2;
+
+  const microsoftAuthService = {
+    getUserAccessToken: async (params: { internalUserId?: number }): Promise<string> => {
+      const key = String(params.internalUserId ?? '?');
+      const injected = engine.decide('auth.delegatedToken', key);
+      if (injected) {
+        metrics.recordInjected('auth.delegatedToken', injected.response?.status ?? 'network');
+        throw new Error(`chaos: delegated token unavailable for user ${key}`);
+      }
+      return `delegated-token-${key}`;
+    },
+  } as unknown as MicrosoftAuthService;
+
+  const appOnlyAuthService = {
+    getAccessToken: async (tenantId: string): Promise<string> => {
+      const injected = engine.decide('auth.appOnlyToken', tenantId);
+      if (injected) {
+        metrics.recordInjected('auth.appOnlyToken', injected.response?.status ?? 'network');
+        throw new Error(`chaos: app-only token unavailable for tenant ${tenantId}`);
+      }
+      return `app-only-token-${tenantId}`;
+    },
+    getTenantId: (): string => defaultTenant.tenantId,
+    invalidateCache: (_tenantId?: string): void => {
+      metrics.mark('auth:invalidateCache');
+    },
+    isEnabled: (): boolean => true,
+  } as unknown as AppOnlyAuthService;
+
+  const userIdConverter = {
+    externalToInternal: async (externalUserId: string): Promise<number> => {
+      metrics.recordDb('converter.externalToInternal');
+      const user = db.users.find((u) => u.externalUserId === externalUserId);
+      if (!user) throw new Error(`chaos: no microsoft_users row for ${externalUserId}`);
+      return user.id;
+    },
+    internalToExternal: async (internalUserId: number): Promise<string> => {
+      metrics.recordDb('converter.internalToExternal');
+      const user = db.users.find((u) => u.id === internalUserId);
+      if (!user) throw new Error(`chaos: no microsoft_users row for id ${internalUserId}`);
+      return user.externalUserId;
+    },
+  } as unknown as UserIdConverterService;
+
+  const rateLimiter = {
+    acquirePermit: async (): Promise<void> => undefined,
+    recordSuccess: async (): Promise<void> => undefined,
+    record503Failure: async (): Promise<void> => undefined,
+    handleRateLimitResponse: async (): Promise<void> => undefined,
+  } as unknown as GraphRateLimiterService;
+
+  const config: MicrosoftOutlookConfig = {
+    clientId: 'chaos-client-id',
+    clientSecret: 'chaos-client-secret',
+    redirectPath: 'auth/microsoft/callback',
+    backendBaseUrl: 'https://host.example.com',
+    basePath: 'api',
+    calendarWebhookPath: '/calendar/webhook',
+  };
+
+  const subscriptionRepo = db.buildSubscriptionRepo() as unknown as OutlookWebhookSubscriptionRepository;
+  const userOrmRepo = db.buildUserOrmRepo() as unknown as Repository<MicrosoftUser>;
+  const tenantOrmRepo = db.buildTenantOrmRepo() as unknown as Repository<MicrosoftTenant>;
+  const tenantConnectionRepo = db.buildTenantConnectionRepo() as unknown as MicrosoftTenantRepository;
+
+  // ── REAL services under test ────────────────────────────────────────
+  const subscriptionService = new MicrosoftSubscriptionService(
+    microsoftAuthService,
+    appOnlyAuthService,
+    subscriptionRepo,
+    eventEmitter,
+    config,
+    userOrmRepo,
+    userIdConverter,
+    rateLimiter,
+  );
+  const tenantUserService = new TenantUserService(tenantOrmRepo, userOrmRepo, appOnlyAuthService, config);
+  const provisioningService = new TenantProvisioningService(
+    tenantUserService,
+    subscriptionService,
+    tenantConnectionRepo,
+    eventEmitter,
+  );
+  const healthService = new HealthService(tenantUserService, subscriptionService, subscriptionRepo, eventEmitter);
+
+  const tenantAuthController = new TenantAuthController(
+    appOnlyAuthService,
+    tenantConnectionRepo,
+    provisioningService,
+    tenantUserService,
+    subscriptionService,
+  );
+  const healthController = new HealthController(healthService);
+
+  return {
+    metrics,
+    engine,
+    graph,
+    db,
+    events,
+    tenants: tenantByKey,
+    defaultTenantId: defaultTenant.tenantId,
+    services: { subscriptionService, tenantUserService, provisioningService, healthService },
+    controllers: { tenantAuthController, healthController },
+    helpers: {
+      msIdOf: (externalUserId: string): string => `ms-${externalUserId}`,
+      internalIdOf: (externalUserId: string): number => {
+        const user = usersByExternalId.get(externalUserId);
+        if (!user) throw new Error(`chaos world: unseeded user ${externalUserId}`);
+        return user.id;
+      },
+      activeDbSubsOf: (externalUserId: string) => {
+        const user = db.users.find((u) => u.externalUserId === externalUserId);
+        return user ? db.activeSubsOfUser(user.id) : [];
+      },
+      eventsNamed: (event: string): CapturedEvent[] => events.filter((e) => e.event === event),
+    },
+  };
+}
+
+export type ChaosWorld = ReturnType<typeof buildChaosWorld>;

--- a/src/mock/chaos/fake-timers.ts
+++ b/src/mock/chaos/fake-timers.ts
@@ -1,0 +1,86 @@
+/**
+ * Fake-timer driver for chaos flows.
+ *
+ * Every sleep in the module funnels through `setTimeout` (chaos latency, `retry.util`'s
+ * exponential backoff, the ≥5s Retry-After waits on 429/503). Faking timers makes those waits
+ * cost *virtual* time only — a chaos storm that would take minutes of real backoff completes in
+ * seconds of CPU — while `Date.now()` still advances so staleness/expiry math stays coherent.
+ */
+
+/** Install fake timers (call before building a chaos world so the clock is coherent). */
+export function installChaosTimers(): void {
+  jest.useFakeTimers({
+    // Keep the real microtask/immediate machinery and real perf counters: the drain loop
+    // below uses setImmediate hops, and ChaosMetrics measures real CPU via performance.now.
+    doNotFake: ['nextTick', 'setImmediate', 'queueMicrotask', 'performance', 'hrtime'],
+  });
+}
+
+export function uninstallChaosTimers(): void {
+  jest.useRealTimers();
+}
+
+const MAX_TICKS = 200_000;
+const MAX_IDLE_HOPS = 50;
+
+/**
+ * Pump fake timers until `promise` settles, then return/throw its result.
+ * Throws if the flow stalls (pending forever with no timers) — a deadlock detector.
+ */
+export async function drain<T>(promise: Promise<T>): Promise<T> {
+  let settled = false;
+  const guarded = promise.then(
+    (value) => {
+      settled = true;
+      return value;
+    },
+    (error: unknown) => {
+      settled = true;
+      throw error;
+    },
+  );
+  // Avoid unhandled-rejection noise while we pump timers; the caller awaits `guarded`.
+  guarded.catch(() => undefined);
+
+  let idleHops = 0;
+  for (let tick = 0; tick < MAX_TICKS && !settled; tick++) {
+    if (jest.getTimerCount() > 0) {
+      idleHops = 0;
+      await jest.runOnlyPendingTimersAsync();
+    } else {
+      // No timers pending — give promise chains a real macrotask hop to progress.
+      await new Promise<void>((resolve) => setImmediate(resolve));
+      idleHops += 1;
+      if (idleHops > MAX_IDLE_HOPS && !settled && jest.getTimerCount() === 0) {
+        throw new Error('drain(): flow stalled — promise pending with no fake timers scheduled');
+      }
+    }
+  }
+  if (!settled) {
+    throw new Error(`drain(): flow did not settle within ${MAX_TICKS} timer ticks`);
+  }
+  return guarded;
+}
+
+/**
+ * Pump fake timers until `predicate()` turns true — for detached background flows
+ * (the 202 endpoints) where there is no promise to await, only an observable effect
+ * (an emitted event, a timeline mark).
+ */
+export async function drainUntil(predicate: () => boolean): Promise<void> {
+  let idleHops = 0;
+  for (let tick = 0; tick < MAX_TICKS; tick++) {
+    if (predicate()) return;
+    if (jest.getTimerCount() > 0) {
+      idleHops = 0;
+      await jest.runOnlyPendingTimersAsync();
+    } else {
+      await new Promise<void>((resolve) => setImmediate(resolve));
+      idleHops += 1;
+      if (idleHops > MAX_IDLE_HOPS && !predicate() && jest.getTimerCount() === 0) {
+        throw new Error('drainUntil(): condition never became true and no fake timers are scheduled');
+      }
+    }
+  }
+  throw new Error(`drainUntil(): condition not reached within ${MAX_TICKS} timer ticks`);
+}

--- a/src/mock/chaos/index.ts
+++ b/src/mock/chaos/index.ts
@@ -1,0 +1,15 @@
+/**
+ * Chaos test harness (test-only; `src/mock` is excluded from the published build).
+ *
+ * Wires the REAL provisioning / subscription / tenant-user / health services to an in-memory
+ * Microsoft Graph and database behind a seeded chaos layer — latency, throttling, server
+ * errors, network drops, and deterministic per-key fail-plans — so host-facing flows can be
+ * exercised at scale and their behaviour, consumption, and recovery verified.
+ */
+export * from './seeded-random';
+export * from './chaos-engine';
+export * from './chaos-metrics';
+export * from './chaos-graph';
+export * from './chaos-db';
+export * from './chaos-world';
+export * from './fake-timers';

--- a/src/mock/chaos/seeded-random.ts
+++ b/src/mock/chaos/seeded-random.ts
@@ -1,0 +1,30 @@
+/**
+ * Deterministic PRNG (mulberry32) for chaos tests. The same seed always produces the same
+ * disruption sequence, so a failing chaos run is reproducible by re-running with its seed.
+ */
+export class SeededRandom {
+  private state: number;
+
+  constructor(public readonly seed: number) {
+    this.state = seed >>> 0;
+  }
+
+  /** Next float in [0, 1). */
+  next(): number {
+    this.state = (this.state + 0x6d2b79f5) >>> 0;
+    let t = this.state;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  }
+
+  /** Integer in [min, max] inclusive. */
+  int(min: number, max: number): number {
+    return min + Math.floor(this.next() * (max - min + 1));
+  }
+
+  /** True with probability p. */
+  chance(p: number): boolean {
+    return p > 0 && this.next() < p;
+  }
+}

--- a/src/repositories/outlook-webhook-subscription.repository.ts
+++ b/src/repositories/outlook-webhook-subscription.repository.ts
@@ -80,6 +80,23 @@ export class OutlookWebhookSubscriptionRepository {
     this.byUserId.clear();
   }
 
+  /**
+   * Deactivate ALL active subscriptions for a tenant in a single UPDATE statement.
+   *
+   * Used by the tenant-disconnect teardown so we flip N rows inactive at once instead of
+   * issuing one UPDATE per subscription. Returns the number of rows affected. Because the
+   * change spans many (unknown) subscriptionIds/userIds, both caches are cleared.
+   */
+  async deactivateAllByTenantId(tenantId: string): Promise<number> {
+    const result = await this.repository.update(
+      { tenantId, isActive: true },
+      { isActive: false, updatedAt: new Date() },
+    );
+    this.bySubscriptionId.clear();
+    this.byUserId.clear();
+    return result.affected ?? 0;
+  }
+
   async findActiveSubscriptions(excludeUserIds?: number[]): Promise<OutlookWebhookSubscription[]> {
     const now = new Date();
     if (excludeUserIds && excludeUserIds.length > 0) {

--- a/src/services/health/health.chaos.spec.ts
+++ b/src/services/health/health.chaos.spec.ts
@@ -1,0 +1,337 @@
+import { Logger } from '@nestjs/common';
+import axios from 'axios';
+import {
+  buildChaosWorld,
+  SeedUser,
+  AxiosMockLike,
+  installChaosTimers,
+  uninstallChaosTimers,
+  drain,
+  drainUntil,
+} from '../../mock/chaos';
+import { UserHealth, HealthCheckResult } from './health.service';
+import { UserHealthStatus } from '../../enums/user-health-status.enum';
+import { MicrosoftUserStatus } from '../../enums/microsoft-user-status.enum';
+import { MicrosoftTenantStatus } from '../../enums/microsoft-tenant-status.enum';
+import { OutlookEventTypes } from '../../enums/event-types.enum';
+
+jest.mock('axios');
+const mockedAxios = axios as jest.Mocked<typeof axios> as unknown as AxiosMockLike;
+
+jest.setTimeout(120_000);
+
+/**
+ * Chaos + scale tests for HealthService.checkUsers / recoverUsers over a 400-user population in
+ * every reachable state, across two tenants (one ACTIVE, one CONSENT_REVOKED), with Graph
+ * disruption on the verify and create paths.
+ *
+ * Behavioural note surfaced by the realistic repo fakes: `checkUsers` reads subscriptions via
+ * `findActiveByUserIds`, whose REAL query excludes rows past `expirationDateTime` — so an
+ * expired subscription is diagnosed as NO_SUBSCRIPTION (not SUBSCRIPTION_EXPIRED). Both are
+ * recoverable, so recovery behaviour is identical; the assertions below encode the real verdict.
+ */
+describe('HealthService — chaos at scale', () => {
+  const SEED = Number(process.env.CHAOS_SEED ?? 20260714);
+  const T1 = 'tenant-t1-guid';
+  const T2 = 'tenant-t2-guid';
+
+  const group = (
+    n: number,
+    prefix: string,
+    build: (i: number) => Omit<SeedUser, 'externalUserId' | 'email'>,
+  ): SeedUser[] =>
+    Array.from({ length: n }, (_, i) => ({
+      externalUserId: `${prefix}-${i}`,
+      email: `${prefix}-${i}@contoso.com`,
+      ...build(i),
+    }));
+
+  /** 400 users covering every verdict. */
+  const seedPopulation = (): SeedUser[] => [
+    ...group(150, 'healthy-ao', () => ({ kind: 'app-only', sub: { mode: 'app-only' } })),
+    ...group(40, 'healthy-del', () => ({ kind: 'delegated', sub: { mode: 'delegated' } })),
+    ...group(50, 'nosub', () => ({ kind: 'app-only', sub: null })),
+    ...group(30, 'expired', () => ({ kind: 'app-only', sub: { mode: 'app-only', expired: true } })),
+    ...group(30, 'stale-ao', () => ({ kind: 'app-only', sub: { mode: 'app-only', stale: true } })),
+    ...group(10, 'stale-del', () => ({ kind: 'delegated', sub: { mode: 'delegated', stale: true } })),
+    ...group(25, 'missing', () => ({ kind: 'app-only', sub: { mode: 'app-only', presentAtGraph: false } })),
+    ...group(20, 'corrupted', () => ({
+      kind: 'delegated',
+      status: MicrosoftUserStatus.CORRUPTED,
+      sub: { mode: 'delegated' },
+    })),
+    ...group(15, 'revoked', () => ({ kind: 'app-only', tenantKey: 'T2', sub: null })),
+    ...group(10, 'inactive', () => ({ kind: 'app-only', isActive: false, sub: null })),
+    ...group(8, 'bare', () => ({ kind: 'bare' })),
+    ...group(12, 'ghost', () => ({ kind: 'bare', inDb: false })),
+  ];
+
+  const TENANTS = [
+    { key: 'T1', tenantId: T1 },
+    { key: 'T2', tenantId: T2, status: MicrosoftTenantStatus.CONSENT_REVOKED },
+  ];
+
+  const idsOf = (seeds: SeedUser[]): string[] => seeds.map((s) => s.externalUserId);
+
+  const histogram = (healths: UserHealth[]): Record<string, number> => {
+    const counts: Record<string, number> = {};
+    for (const h of healths) counts[h.status] = (counts[h.status] ?? 0) + 1;
+    return counts;
+  };
+
+  beforeAll(() => {
+    Logger.overrideLogger(false);
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    installChaosTimers();
+  });
+
+  afterEach(() => {
+    uninstallChaosTimers();
+  });
+
+  it('DB-only check of 400 mixed-state users: exact verdict histogram, ZERO Graph traffic, two bulk reads', async () => {
+    const seeds = seedPopulation();
+    const world = buildChaosWorld(mockedAxios, { seed: SEED, tenants: TENANTS, users: seeds });
+
+    const healths = await drain(world.services.healthService.checkUsers(idsOf(seeds)));
+
+    expect(healths).toHaveLength(400);
+    expect(histogram(healths)).toEqual({
+      [UserHealthStatus.HEALTHY]: 215, // 150 + 40 + 25 drifted (verify off ⇒ DB-healthy)
+      [UserHealthStatus.NO_SUBSCRIPTION]: 80, // 50 without + 30 expired (real query excludes expired)
+      [UserHealthStatus.SUBSCRIPTION_STALE]: 40,
+      [UserHealthStatus.NEEDS_REAUTH]: 20,
+      [UserHealthStatus.NEEDS_ADMIN]: 15,
+      [UserHealthStatus.INACTIVE]: 10,
+      [UserHealthStatus.NOT_MAPPED]: 8,
+      [UserHealthStatus.UNKNOWN]: 12,
+    });
+
+    // Consumption: a DB-only check generates ZERO Graph traffic on ANY route…
+    expect(world.metrics.attempts.size).toBe(0);
+    // …and reads the database in TWO bulk queries, not 400.
+    expect(world.metrics.dbCallsFor('users.find')).toBe(1);
+    expect(world.metrics.dbCallsFor('subs.findActiveByUserIds')).toBe(1);
+
+    // Input order is preserved (the documented contract) — even through the bulk path.
+    const ids = idsOf(seeds);
+    for (let i = 0; i < ids.length; i++) {
+      expect(healths[i].externalUserId).toBe(ids[i]);
+    }
+
+    console.log(world.metrics.report(`health check DB-only N=400 seed=${SEED}`));
+  });
+
+  it('verifyAtGraph: drifted subscriptions detected exactly; inconclusive Graph answers never downgrade a verdict', async () => {
+    const seeds = seedPopulation();
+    const world = buildChaosWorld(mockedAxios, { seed: SEED, tenants: TENANTS, users: seeds });
+
+    // 6 genuinely-healthy users whose verify call hard-fails (inconclusive 'unknown').
+    const inconclusive = seeds.filter((s) => s.externalUserId.startsWith('healthy-ao')).slice(0, 6);
+    for (const s of inconclusive) {
+      const subId = world.helpers.activeDbSubsOf(s.externalUserId)[0].subscriptionId;
+      world.engine.alwaysFail('subs.get', subId, 500);
+    }
+
+    const healths = await drain(world.services.healthService.checkUsers(idsOf(seeds), { verifyAtGraph: true }));
+
+    const counts = histogram(healths);
+    expect(counts[UserHealthStatus.MISSING_AT_GRAPH]).toBe(25);
+    expect(counts[UserHealthStatus.HEALTHY]).toBe(190); // 215 − 25 drifted; the 6 inconclusive stay HEALTHY
+    // Only DB-healthy users were verified: 215 logical calls; the 6 sticky-500s retried
+    // (maxRetries=3 ⇒ 4 attempts each), everything else answered once.
+    expect(world.metrics.attemptsFor('subs.get')).toBe(209 + 6 * 4);
+    for (const s of inconclusive) {
+      const health = healths.find((h) => h.externalUserId === s.externalUserId);
+      expect(health?.status).toBe(UserHealthStatus.HEALTHY);
+    }
+  });
+
+  it('verify storm: random 429s + latency — DB-decided verdicts stay exact, totals conserve, ceiling holds', async () => {
+    const seeds = seedPopulation();
+    const world = buildChaosWorld(mockedAxios, {
+      seed: SEED,
+      tenants: TENANTS,
+      users: seeds,
+      graphRates: { throttle429: 0.15 },
+      graphLatencyMs: { min: 1, max: 10 },
+    });
+
+    const healths = await drain(world.services.healthService.checkUsers(idsOf(seeds), { verifyAtGraph: true }));
+
+    const counts = histogram(healths);
+    // Conservation across all verdicts.
+    expect(healths).toHaveLength(400);
+    // Verdicts that never touch Graph are immune to Graph weather.
+    expect(counts[UserHealthStatus.NEEDS_REAUTH]).toBe(20);
+    expect(counts[UserHealthStatus.NEEDS_ADMIN]).toBe(15);
+    expect(counts[UserHealthStatus.INACTIVE]).toBe(10);
+    expect(counts[UserHealthStatus.NOT_MAPPED]).toBe(8);
+    expect(counts[UserHealthStatus.UNKNOWN]).toBe(12);
+    expect(counts[UserHealthStatus.NO_SUBSCRIPTION]).toBe(80);
+    expect(counts[UserHealthStatus.SUBSCRIPTION_STALE]).toBe(40);
+    // Graph-decided split can shift under throttling exhaustion, but only between these two.
+    expect((counts[UserHealthStatus.HEALTHY] ?? 0) + (counts[UserHealthStatus.MISSING_AT_GRAPH] ?? 0)).toBe(215);
+    expect(counts[UserHealthStatus.MISSING_AT_GRAPH] ?? 0).toBeLessThanOrEqual(25);
+    expect(world.metrics.totalInjected()).toBeGreaterThan(0);
+    expect(world.metrics.peakInFlight).toBeLessThanOrEqual(5);
+
+    console.log(world.metrics.report(`health verify storm N=400 seed=${SEED}`));
+  });
+
+  it('recoverUsers: fixes every recoverable state via the right auth mode, reports the rest, and converges on rerun', async () => {
+    const seeds = seedPopulation();
+    const world = buildChaosWorld(mockedAxios, { seed: SEED, tenants: TENANTS, users: seeds });
+
+    // Planned create failures: 5 app-only recoveries and 4 delegated recoveries hard-fail.
+    const appOnlyFails = seeds.filter((s) => s.externalUserId.startsWith('nosub')).slice(0, 5);
+    const delegatedFails = seeds.filter((s) => s.externalUserId.startsWith('stale-del')).slice(0, 4);
+    for (const s of appOnlyFails) world.engine.alwaysFail('subs.create', world.helpers.msIdOf(s.externalUserId), 500);
+    for (const s of delegatedFails) {
+      world.engine.alwaysFail('subs.create', `me:${world.helpers.internalIdOf(s.externalUserId)}`, 500);
+    }
+
+    const result = await drain(world.services.healthService.recoverUsers(idsOf(seeds), { verifyAtGraph: true }));
+
+    // Recoverable = 50 nosub + 30 expired + 30 stale-ao + 10 stale-del + 25 drifted = 145.
+    expect(result.total).toBe(400);
+    expect(result.healthy).toBe(190);
+    expect(result.recovered).toBe(145 - 9);
+    expect(result.failed).toBe(9);
+    expect(result.unrecoverable).toBe(20 + 15 + 10 + 8 + 12);
+
+    // Routing: delegated users were recovered via /me/events, app-only via /users/{id}/events.
+    const delegatedRecovered = result.results.filter(
+      (r) => r.externalUserId.startsWith('stale-del') && r.action === 'recreated',
+    );
+    expect(delegatedRecovered).toHaveLength(6);
+    for (const r of result.results.filter((x) => x.action === 'recreated')) {
+      const subs = world.helpers.activeDbSubsOf(r.externalUserId);
+      expect(subs).toHaveLength(1);
+      const expectDelegated = r.externalUserId.startsWith('stale-del');
+      expect(subs[0].resource.startsWith(expectDelegated ? '/me/' : '/users/')).toBe(true);
+    }
+    // Unrecoverable users were REPORTED, never re-created. Check BOTH create-key shapes
+    // (app-only keys by Microsoft id, delegated keys by `me:{internalId}`) so the assertion
+    // can't be satisfied vacuously by looking up the wrong namespace.
+    for (const prefix of ['corrupted', 'revoked', 'inactive', 'bare'] as const) {
+      const samples = seeds.filter((s) => s.externalUserId.startsWith(prefix));
+      expect(samples.length).toBeGreaterThan(0);
+      for (const sample of samples) {
+        expect(world.metrics.attemptsForKey('subs.create', world.helpers.msIdOf(sample.externalUserId))).toBe(0);
+        expect(
+          world.metrics.attemptsForKey('subs.create', `me:${world.helpers.internalIdOf(sample.externalUserId)}`),
+        ).toBe(0);
+      }
+    }
+    // Belt-and-braces: total create attempts equal exactly the recovered creates plus the
+    // exhausted retries of the 9 planned failures (maxRetries=7 ⇒ 8 attempts each).
+    expect(world.metrics.attemptsFor('subs.create')).toBe(136 + 9 * 8);
+    const completed = world.helpers.eventsNamed(OutlookEventTypes.USER_HEALTH_RECOVERY_COMPLETED);
+    expect(completed).toHaveLength(1);
+
+    // Convergence: a second run finds the recovered users HEALTHY and re-attempts only the 9 failures.
+    const rerun = await drain(world.services.healthService.recoverUsers(idsOf(seeds), { verifyAtGraph: true }));
+    expect(rerun.healthy).toBe(190 + 136);
+    expect(rerun.recovered).toBe(0);
+    expect(rerun.failed).toBe(9);
+    expect(rerun.unrecoverable).toBe(65);
+
+    console.log(world.metrics.report(`health recover N=400 (two runs) seed=${SEED}`));
+  });
+
+  it('host contract: POST health/recover returns before the background recovery completes (mixed population)', async () => {
+    const seeds: SeedUser[] = [
+      ...group(50, 'ok', () => ({ kind: 'app-only' as const, sub: { mode: 'app-only' as const } })),
+      ...group(40, 'fix', () => ({ kind: 'app-only' as const, sub: null })),
+      ...group(20, 'stuck', () => ({
+        kind: 'delegated' as const,
+        status: MicrosoftUserStatus.CORRUPTED,
+        sub: null,
+      })),
+    ];
+    const world = buildChaosWorld(mockedAxios, {
+      seed: SEED,
+      tenants: TENANTS,
+      users: seeds,
+      graphLatencyMs: { min: 2, max: 15 },
+    });
+
+    const response = world.controllers.healthController.recoverUsers({ externalUserIds: idsOf(seeds) });
+
+    expect(response.totalRequested).toBe(110);
+    expect(world.helpers.eventsNamed(OutlookEventTypes.USER_HEALTH_RECOVERY_COMPLETED)).toHaveLength(0);
+
+    await drainUntil(
+      () => world.helpers.eventsNamed(OutlookEventTypes.USER_HEALTH_RECOVERY_COMPLETED).length === 1,
+    );
+    const summary = world.helpers.eventsNamed(OutlookEventTypes.USER_HEALTH_RECOVERY_COMPLETED)[0]
+      .payload as HealthCheckResult;
+    // Latency-only chaos ⇒ deterministic outcome: the exact split, not just the sum.
+    expect(summary).toMatchObject({ total: 110, healthy: 50, recovered: 40, unrecoverable: 20, failed: 0 });
+    for (const s of seeds.filter((x) => x.externalUserId.startsWith('fix'))) {
+      expect(world.helpers.activeDbSubsOf(s.externalUserId)).toHaveLength(1);
+    }
+  });
+
+  it('single-user endpoint passthrough: unknown id yields UNKNOWN', async () => {
+    const world = buildChaosWorld(mockedAxios, { seed: SEED, tenants: TENANTS, users: [] });
+
+    const health = await drain(world.controllers.healthController.getUserHealth('nobody', 'false'));
+
+    expect(health.status).toBe(UserHealthStatus.UNKNOWN);
+    expect(health.connected).toBe(false);
+  });
+
+  it('GET health/:id with verifyAtGraph under throttling: a real healthy user resolves HEALTHY through retries', async () => {
+    const seeds: SeedUser[] = [
+      { externalUserId: 'one', email: 'one@contoso.com', kind: 'app-only', sub: { mode: 'app-only' } },
+    ];
+    const world = buildChaosWorld(mockedAxios, { seed: SEED, tenants: TENANTS, users: seeds });
+    const subId = world.helpers.activeDbSubsOf('one')[0].subscriptionId;
+    world.engine.failTimes('subs.get', subId, 2, 429); // deterministic transient throttling
+
+    const health = await drain(world.controllers.healthController.getUserHealth('one', 'true'));
+
+    expect(health.status).toBe(UserHealthStatus.HEALTHY);
+    expect(health.connected).toBe(true);
+    expect(world.metrics.attemptsForKey('subs.get', subId)).toBe(3); // 2 throttles + 1 success
+  });
+
+  it('POST health/check endpoint: bulk verdicts through the controller (DTO path), order preserved', async () => {
+    const seeds: SeedUser[] = [
+      { externalUserId: 'ok-1', email: 'ok-1@contoso.com', kind: 'app-only', sub: { mode: 'app-only' } },
+      { externalUserId: 'gone-1', email: 'gone-1@contoso.com', kind: 'app-only', sub: null },
+      { externalUserId: 'dead-1', email: 'dead-1@contoso.com', kind: 'delegated', status: MicrosoftUserStatus.CORRUPTED, sub: null },
+    ];
+    const world = buildChaosWorld(mockedAxios, { seed: SEED, tenants: TENANTS, users: seeds });
+
+    const healths = await drain(
+      world.controllers.healthController.checkUsers({ externalUserIds: ['ok-1', 'gone-1', 'dead-1', 'ghost-1'] }),
+    );
+
+    expect(healths.map((h) => h.status)).toEqual([
+      UserHealthStatus.HEALTHY,
+      UserHealthStatus.NO_SUBSCRIPTION,
+      UserHealthStatus.NEEDS_REAUTH,
+      UserHealthStatus.UNKNOWN,
+    ]);
+  });
+
+  it('recoverUser (single): one no-subscription user is recreated end to end', async () => {
+    const seeds: SeedUser[] = [
+      { externalUserId: 'solo', email: 'solo@contoso.com', kind: 'app-only', sub: null },
+    ];
+    const world = buildChaosWorld(mockedAxios, { seed: SEED, tenants: TENANTS, users: seeds });
+
+    const report = await drain(world.services.healthService.recoverUser('solo'));
+
+    expect(report.action).toBe('recreated');
+    expect(report.status).toBe(UserHealthStatus.HEALTHY);
+    expect(world.helpers.activeDbSubsOf('solo')).toHaveLength(1);
+    expect(world.graph.subscriptionIdsForResourcePrefix('/users/')).toHaveLength(1);
+  });
+});

--- a/src/services/health/health.service.spec.ts
+++ b/src/services/health/health.service.spec.ts
@@ -1,0 +1,237 @@
+import { EventEmitter2 } from '@nestjs/event-emitter';
+import { HealthService } from './health.service';
+import { TenantUserService } from '../tenant/tenant-user.service';
+import { MicrosoftSubscriptionService } from '../subscription/microsoft-subscription.service';
+import { OutlookWebhookSubscriptionRepository } from '../../repositories/outlook-webhook-subscription.repository';
+import { MicrosoftUser } from '../../entities/microsoft-user.entity';
+import { MicrosoftTenant } from '../../entities/microsoft-tenant.entity';
+import { OutlookWebhookSubscription } from '../../entities/outlook-webhook-subscription.entity';
+import { MicrosoftUserStatus } from '../../enums/microsoft-user-status.enum';
+import { MicrosoftTenantStatus } from '../../enums/microsoft-tenant-status.enum';
+import { UserHealthStatus } from '../../enums/user-health-status.enum';
+import { OutlookEventTypes } from '../../enums/event-types.enum';
+
+const HOUR = 60 * 60 * 1000;
+const future = () => new Date(Date.now() + 72 * HOUR);
+const past = (hours: number) => new Date(Date.now() - hours * HOUR);
+
+describe('HealthService', () => {
+  let service: HealthService;
+  let tenantUserService: jest.Mocked<Pick<TenantUserService, 'findUsersByExternalIds'>>;
+  let subscriptionService: jest.Mocked<
+    Pick<
+      MicrosoftSubscriptionService,
+      'createWebhookSubscription' | 'createAppOnlyWebhookSubscription' | 'verifySubscriptionAtGraph'
+    >
+  >;
+  let subscriptionRepo: jest.Mocked<Pick<OutlookWebhookSubscriptionRepository, 'findActiveByUserIds'>>;
+  let eventEmitter: jest.Mocked<Pick<EventEmitter2, 'emit'>>;
+
+  const tenantId = 'tenant-guid';
+
+  // A delegated user (has a refresh token, no tenant mapping).
+  const delegatedUser = (id: number, externalUserId: string, over: Partial<MicrosoftUser> = {}): MicrosoftUser =>
+    ({
+      id, externalUserId, isActive: true, status: MicrosoftUserStatus.ACTIVE,
+      refreshToken: 'rt', microsoftUserId: null, tenant: null, ...over,
+    }) as MicrosoftUser;
+
+  // An app-only user (mapped into an ACTIVE tenant).
+  const appOnlyUser = (id: number, externalUserId: string, over: Partial<MicrosoftUser> = {}): MicrosoftUser =>
+    ({
+      id, externalUserId, isActive: true, status: MicrosoftUserStatus.ACTIVE,
+      refreshToken: null, microsoftUserId: `ms-${externalUserId}`,
+      tenant: { tenantId, status: MicrosoftTenantStatus.ACTIVE, isActive: true } as MicrosoftTenant,
+      ...over,
+    }) as MicrosoftUser;
+
+  const calendarSub = (userId: number, over: Partial<OutlookWebhookSubscription> = {}): OutlookWebhookSubscription =>
+    ({
+      subscriptionId: `sub-${userId}`, userId, resource: '/me/events', isActive: true,
+      expirationDateTime: future(), lastNotificationAt: past(1), createdAt: past(1), tenantId: null, ...over,
+    }) as OutlookWebhookSubscription;
+
+  beforeEach(() => {
+    tenantUserService = { findUsersByExternalIds: jest.fn().mockResolvedValue([]) };
+    subscriptionService = {
+      createWebhookSubscription: jest.fn().mockResolvedValue({ id: 'new-delegated' }),
+      createAppOnlyWebhookSubscription: jest.fn().mockResolvedValue({ id: 'new-app-only' }),
+      verifySubscriptionAtGraph: jest.fn().mockResolvedValue('present'),
+    };
+    subscriptionRepo = { findActiveByUserIds: jest.fn().mockResolvedValue([]) };
+    eventEmitter = { emit: jest.fn() };
+
+    service = new HealthService(
+      tenantUserService as unknown as TenantUserService,
+      subscriptionService as unknown as MicrosoftSubscriptionService,
+      subscriptionRepo as unknown as OutlookWebhookSubscriptionRepository,
+      eventEmitter as unknown as EventEmitter2,
+    );
+  });
+
+  describe('checkUser — verdicts', () => {
+    it('HEALTHY when active user has a live calendar subscription', async () => {
+      tenantUserService.findUsersByExternalIds.mockResolvedValueOnce([delegatedUser(1, 'u1')]);
+      subscriptionRepo.findActiveByUserIds.mockResolvedValueOnce([calendarSub(1)]);
+
+      const health = await service.checkUser('u1');
+
+      expect(health.status).toBe(UserHealthStatus.HEALTHY);
+      expect(health.connected).toBe(true);
+      expect(health.recoverable).toBe(false);
+      expect(health.subscriptionId).toBe('sub-1');
+    });
+
+    it('NO_SUBSCRIPTION (recoverable) when the user has no active sub', async () => {
+      tenantUserService.findUsersByExternalIds.mockResolvedValueOnce([appOnlyUser(2, 'u2')]);
+      subscriptionRepo.findActiveByUserIds.mockResolvedValueOnce([]);
+
+      const health = await service.checkUser('u2');
+
+      expect(health.status).toBe(UserHealthStatus.NO_SUBSCRIPTION);
+      expect(health.connected).toBe(false);
+      expect(health.recoverable).toBe(true);
+      expect(health.authMode).toBe('app-only');
+    });
+
+    it('SUBSCRIPTION_EXPIRED (recoverable) when the sub is past expiry', async () => {
+      tenantUserService.findUsersByExternalIds.mockResolvedValueOnce([delegatedUser(1, 'u1')]);
+      subscriptionRepo.findActiveByUserIds.mockResolvedValueOnce([calendarSub(1, { expirationDateTime: past(1) })]);
+
+      const health = await service.checkUser('u1');
+
+      expect(health.status).toBe(UserHealthStatus.SUBSCRIPTION_EXPIRED);
+      expect(health.recoverable).toBe(true);
+    });
+
+    it('SUBSCRIPTION_STALE (recoverable) when no notification within the stale window', async () => {
+      tenantUserService.findUsersByExternalIds.mockResolvedValueOnce([delegatedUser(1, 'u1')]);
+      subscriptionRepo.findActiveByUserIds.mockResolvedValueOnce([
+        calendarSub(1, { lastNotificationAt: past(48), createdAt: past(72) }),
+      ]);
+
+      const health = await service.checkUser('u1');
+
+      expect(health.status).toBe(UserHealthStatus.SUBSCRIPTION_STALE);
+      expect(health.recoverable).toBe(true);
+    });
+
+    it('NEEDS_REAUTH (not recoverable) when the delegated token is CORRUPTED', async () => {
+      tenantUserService.findUsersByExternalIds.mockResolvedValueOnce([
+        delegatedUser(1, 'u1', { status: MicrosoftUserStatus.CORRUPTED }),
+      ]);
+      subscriptionRepo.findActiveByUserIds.mockResolvedValueOnce([calendarSub(1)]);
+
+      const health = await service.checkUser('u1');
+
+      expect(health.status).toBe(UserHealthStatus.NEEDS_REAUTH);
+      expect(health.recoverable).toBe(false);
+    });
+
+    it('NEEDS_ADMIN (not recoverable) when the app-only tenant is not ACTIVE', async () => {
+      tenantUserService.findUsersByExternalIds.mockResolvedValueOnce([
+        appOnlyUser(2, 'u2', {
+          tenant: { tenantId, status: MicrosoftTenantStatus.CONSENT_REVOKED, isActive: false } as MicrosoftTenant,
+        }),
+      ]);
+
+      const health = await service.checkUser('u2');
+
+      expect(health.status).toBe(UserHealthStatus.NEEDS_ADMIN);
+      expect(health.recoverable).toBe(false);
+    });
+
+    it('INACTIVE when the row is soft-deleted', async () => {
+      tenantUserService.findUsersByExternalIds.mockResolvedValueOnce([delegatedUser(1, 'u1', { isActive: false })]);
+
+      const health = await service.checkUser('u1');
+
+      expect(health.status).toBe(UserHealthStatus.INACTIVE);
+      expect(health.recoverable).toBe(false);
+    });
+
+    it('UNKNOWN when there is no user record', async () => {
+      tenantUserService.findUsersByExternalIds.mockResolvedValueOnce([]);
+
+      const health = await service.checkUser('ghost');
+
+      expect(health.status).toBe(UserHealthStatus.UNKNOWN);
+    });
+
+    it('MISSING_AT_GRAPH when verifyAtGraph finds a DB-healthy sub gone at Microsoft', async () => {
+      tenantUserService.findUsersByExternalIds.mockResolvedValueOnce([delegatedUser(1, 'u1')]);
+      subscriptionRepo.findActiveByUserIds.mockResolvedValueOnce([calendarSub(1)]);
+      subscriptionService.verifySubscriptionAtGraph.mockResolvedValueOnce('missing');
+
+      const health = await service.checkUser('u1', { verifyAtGraph: true });
+
+      expect(subscriptionService.verifySubscriptionAtGraph).toHaveBeenCalled();
+      expect(health.status).toBe(UserHealthStatus.MISSING_AT_GRAPH);
+      expect(health.recoverable).toBe(true);
+    });
+
+    it('stays HEALTHY when verifyAtGraph is inconclusive (unknown)', async () => {
+      tenantUserService.findUsersByExternalIds.mockResolvedValueOnce([delegatedUser(1, 'u1')]);
+      subscriptionRepo.findActiveByUserIds.mockResolvedValueOnce([calendarSub(1)]);
+      subscriptionService.verifySubscriptionAtGraph.mockResolvedValueOnce('unknown');
+
+      const health = await service.checkUser('u1', { verifyAtGraph: true });
+
+      expect(health.status).toBe(UserHealthStatus.HEALTHY);
+    });
+  });
+
+  describe('recoverUsers — auto-fix the fixable, report the rest', () => {
+    it('routes recovery by auth mode and reports the unrecoverable', async () => {
+      const users = [
+        delegatedUser(1, 'healthy'),
+        appOnlyUser(2, 'app-nosub'),
+        delegatedUser(3, 'deleg-nosub'),
+        delegatedUser(4, 'corrupted', { status: MicrosoftUserStatus.CORRUPTED }),
+      ];
+      tenantUserService.findUsersByExternalIds.mockResolvedValueOnce(users);
+      // Only the healthy user has an active sub.
+      subscriptionRepo.findActiveByUserIds.mockResolvedValueOnce([calendarSub(1)]);
+
+      const result = await service.recoverUsers(['healthy', 'app-nosub', 'deleg-nosub', 'corrupted']);
+
+      expect(result.total).toBe(4);
+      expect(result.healthy).toBe(1);
+      expect(result.recovered).toBe(2);
+      expect(result.unrecoverable).toBe(1);
+      expect(result.failed).toBe(0);
+
+      // App-only recreate goes through the app-only path with the resolved ids.
+      expect(subscriptionService.createAppOnlyWebhookSubscription).toHaveBeenCalledWith({
+        tenantId,
+        microsoftUserId: 'ms-app-nosub',
+        externalUserId: 'app-nosub',
+      });
+      // Delegated recreate goes through the delegated path.
+      expect(subscriptionService.createWebhookSubscription).toHaveBeenCalledWith('deleg-nosub');
+      // CORRUPTED is reported, never re-created.
+      expect(subscriptionService.createWebhookSubscription).not.toHaveBeenCalledWith('corrupted');
+      expect(subscriptionService.createAppOnlyWebhookSubscription).toHaveBeenCalledTimes(1);
+      expect(subscriptionService.createWebhookSubscription).toHaveBeenCalledTimes(1);
+
+      // Completion event carries the summary.
+      expect(eventEmitter.emit).toHaveBeenCalledWith(
+        OutlookEventTypes.USER_HEALTH_RECOVERY_COMPLETED,
+        expect.objectContaining({ recovered: 2, unrecoverable: 1 }),
+      );
+    });
+
+    it('counts a recovery failure without aborting the batch', async () => {
+      tenantUserService.findUsersByExternalIds.mockResolvedValueOnce([delegatedUser(3, 'deleg-nosub')]);
+      subscriptionRepo.findActiveByUserIds.mockResolvedValueOnce([]);
+      subscriptionService.createWebhookSubscription.mockRejectedValueOnce(new Error('graph down'));
+
+      const result = await service.recoverUsers(['deleg-nosub']);
+
+      expect(result.failed).toBe(1);
+      expect(result.recovered).toBe(0);
+      expect(result.results[0].action).toBe('recovery_failed');
+      expect(result.results[0].recoveryError).toContain('graph down');
+    });
+  });
+});

--- a/src/services/health/health.service.ts
+++ b/src/services/health/health.service.ts
@@ -1,0 +1,329 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { EventEmitter2 } from '@nestjs/event-emitter';
+import { TenantUserService } from '../tenant/tenant-user.service';
+import { MicrosoftSubscriptionService } from '../subscription/microsoft-subscription.service';
+import { OutlookWebhookSubscriptionRepository } from '../../repositories/outlook-webhook-subscription.repository';
+import { MicrosoftUser } from '../../entities/microsoft-user.entity';
+import { OutlookWebhookSubscription } from '../../entities/outlook-webhook-subscription.entity';
+import { MicrosoftUserStatus } from '../../enums/microsoft-user-status.enum';
+import { MicrosoftTenantStatus } from '../../enums/microsoft-tenant-status.enum';
+import { UserHealthStatus } from '../../enums/user-health-status.enum';
+import { OutlookEventTypes } from '../../enums/event-types.enum';
+import { mapWithConcurrency } from '../../utils/concurrent-map.util';
+
+/** How a user authenticates — determines which subscription to check / recreate. */
+export type UserAuthMode = 'delegated' | 'app-only' | 'none';
+
+/** Options for a health check. */
+export interface HealthCheckOptions {
+  /** Also verify the subscription still exists at Microsoft Graph (extra Graph calls). */
+  verifyAtGraph?: boolean;
+}
+
+/** Per-user health verdict. Only `HEALTHY` (and `connected: true`) means connected. */
+export interface UserHealth {
+  externalUserId: string;
+  connected: boolean;
+  status: UserHealthStatus;
+  authMode: UserAuthMode;
+  /** Whether the state can be auto-fixed by recreating the subscription. */
+  recoverable: boolean;
+  subscriptionId?: string;
+  microsoftUserId?: string;
+  tenantId?: string;
+  reason?: string;
+}
+
+/** A health verdict plus the recovery action that was taken. */
+export interface UserHealthReport extends UserHealth {
+  action: 'none' | 'recreated' | 'recovery_failed' | 'reported';
+  newSubscriptionId?: string;
+  recoveryError?: string;
+}
+
+/** Summary of a bulk recover run. `total = healthy + recovered + unrecoverable + failed`. */
+export interface HealthCheckResult {
+  total: number;
+  healthy: number;
+  recovered: number;
+  unrecoverable: number;
+  failed: number;
+  results: UserHealthReport[];
+}
+
+/**
+ * Diagnoses and recovers user connection health across delegated and app-only auth.
+ *
+ * "Healthy" combines the `microsoft_users` row (exists, active, status) and its active Outlook
+ * **calendar** subscription (present, not expired, receiving notifications), and — when
+ * `verifyAtGraph` is set — a live Microsoft Graph check. Anything else gets a specific verdict.
+ *
+ * Recovery is auth-mode-aware and composes existing primitives: it recreates fixable states
+ * (missing / expired / stale / gone-at-Graph) via the delegated or app-only create (both of which
+ * remove a stale subscription first), and **reports** the states a human must resolve
+ * (`NEEDS_REAUTH`, `NEEDS_ADMIN`, `INACTIVE`, …) instead of looping on them.
+ *
+ * This is a facade over the existing status model + recovery primitives — it does not add new
+ * state or schedulers; the 6-hour / 3am crons keep running independently.
+ */
+@Injectable()
+export class HealthService {
+  private readonly logger = new Logger(HealthService.name);
+
+  /** A subscription with no notification since this many hours ago is considered stale. */
+  private readonly STALE_HOURS = 24;
+
+  /** Max concurrent Graph verifications / recoveries — gentle on Graph rate limits. */
+  private readonly HEALTH_CONCURRENCY = 5;
+
+  constructor(
+    private readonly tenantUserService: TenantUserService,
+    private readonly subscriptionService: MicrosoftSubscriptionService,
+    private readonly webhookSubscriptionRepository: OutlookWebhookSubscriptionRepository,
+    private readonly eventEmitter: EventEmitter2,
+  ) {}
+
+  /**
+   * Diagnose a single user's connection health.
+   */
+  async checkUser(externalUserId: string, opts?: HealthCheckOptions): Promise<UserHealth> {
+    const [health] = await this.checkUsers([externalUserId], opts);
+    return health;
+  }
+
+  /**
+   * Diagnose a batch of users. Two bulk DB reads (user rows + active subscriptions); when
+   * `verifyAtGraph` is set, the otherwise-healthy users are verified at Graph at bounded
+   * concurrency. Results preserve input order.
+   */
+  async checkUsers(externalUserIds: string[], opts?: HealthCheckOptions): Promise<UserHealth[]> {
+    if (externalUserIds.length === 0) {
+      return [];
+    }
+
+    const rows = await this.tenantUserService.findUsersByExternalIds(externalUserIds);
+    const userByExternalId = new Map(rows.map((row) => [row.externalUserId, row]));
+
+    const userIds = rows.map((row) => row.id);
+    const activeSubs = userIds.length
+      ? await this.webhookSubscriptionRepository.findActiveByUserIds(userIds)
+      : [];
+    const calendarSubByUserId = this.indexCalendarSubscriptions(activeSubs);
+
+    const healths = externalUserIds.map((externalUserId) => {
+      const user = userByExternalId.get(externalUserId);
+      const sub = user ? calendarSubByUserId.get(user.id) ?? null : null;
+      return this.diagnose(externalUserId, user, sub);
+    });
+
+    if (!opts?.verifyAtGraph) {
+      return healths;
+    }
+
+    // Verify the DB-healthy ones against Graph; a 404 downgrades to MISSING_AT_GRAPH.
+    return mapWithConcurrency(healths, this.HEALTH_CONCURRENCY, async (health) => {
+      if (health.status !== UserHealthStatus.HEALTHY || !health.subscriptionId) {
+        return health;
+      }
+      const user = userByExternalId.get(health.externalUserId);
+      const sub = user ? calendarSubByUserId.get(user.id) : undefined;
+      if (!sub) {
+        return health;
+      }
+      const graph = await this.subscriptionService.verifySubscriptionAtGraph(sub);
+      if (graph === 'missing') {
+        return {
+          ...health,
+          connected: false,
+          status: UserHealthStatus.MISSING_AT_GRAPH,
+          recoverable: true,
+          reason: 'Subscription not found at Microsoft Graph',
+        };
+      }
+      // 'present' or 'unknown' — keep the DB verdict (don't downgrade on an inconclusive check).
+      return health;
+    });
+  }
+
+  /**
+   * Diagnose then recover a batch of users: auto-fix the recoverable ones (recreate the
+   * subscription via their auth mode) and report the rest. Emits
+   * {@link OutlookEventTypes.USER_HEALTH_RECOVERY_COMPLETED} with the summary.
+   */
+  async recoverUsers(externalUserIds: string[], opts?: HealthCheckOptions): Promise<HealthCheckResult> {
+    const correlationId = `health-recover-${Date.now()}`;
+    const healths = await this.checkUsers(externalUserIds, opts);
+
+    const reports = await mapWithConcurrency(
+      healths,
+      this.HEALTH_CONCURRENCY,
+      (health) => this.recoverOne(health, correlationId),
+    );
+
+    const summary: HealthCheckResult = {
+      total: reports.length,
+      healthy: reports.filter((r) => r.action === 'none').length,
+      recovered: reports.filter((r) => r.action === 'recreated').length,
+      unrecoverable: reports.filter((r) => r.action === 'reported').length,
+      failed: reports.filter((r) => r.action === 'recovery_failed').length,
+      results: reports,
+    };
+
+    this.logger.log(
+      `[${correlationId}] Health recovery complete: ${summary.healthy} healthy, ` +
+      `${summary.recovered} recovered, ${summary.unrecoverable} need attention, ${summary.failed} failed`,
+    );
+    this.eventEmitter.emit(OutlookEventTypes.USER_HEALTH_RECOVERY_COMPLETED, summary);
+
+    return summary;
+  }
+
+  /** Diagnose then recover a single user. */
+  async recoverUser(externalUserId: string, opts?: HealthCheckOptions): Promise<UserHealthReport> {
+    const health = await this.checkUser(externalUserId, opts);
+    return this.recoverOne(health, `health-recover-${Date.now()}`);
+  }
+
+  // ── internals ──────────────────────────────────────────────────────────
+
+  /**
+   * Pure DB-based diagnosis for one user. `verifyAtGraph` is applied by the caller afterwards.
+   */
+  private diagnose(
+    externalUserId: string,
+    user: MicrosoftUser | undefined,
+    sub: OutlookWebhookSubscription | null,
+  ): UserHealth {
+    const base = { externalUserId, connected: false, authMode: 'none' as UserAuthMode, recoverable: false };
+
+    if (!user) {
+      return { ...base, status: UserHealthStatus.UNKNOWN, reason: 'No Microsoft user record' };
+    }
+    if (!user.isActive) {
+      return { ...base, status: UserHealthStatus.INACTIVE, reason: 'User is soft-deleted (isActive=false)' };
+    }
+
+    const authMode = this.authModeOf(user);
+    const microsoftUserId = user.microsoftUserId ?? undefined;
+    const tenantId = user.tenant?.tenantId;
+    const withIds = { ...base, authMode, microsoftUserId, tenantId };
+
+    // Dead delegated token — needs the user to re-authenticate; not auto-recoverable.
+    if (user.status === MicrosoftUserStatus.CORRUPTED) {
+      return { ...withIds, status: UserHealthStatus.NEEDS_REAUTH, reason: 'Delegated token is invalid (CORRUPTED)' };
+    }
+
+    if (authMode === 'app-only') {
+      const tenant = user.tenant;
+      if (!tenant || !microsoftUserId) {
+        return { ...withIds, status: UserHealthStatus.NOT_MAPPED, reason: 'No tenant mapping' };
+      }
+      if (!tenant.isActive || tenant.status !== MicrosoftTenantStatus.ACTIVE) {
+        return {
+          ...withIds,
+          status: UserHealthStatus.NEEDS_ADMIN,
+          reason: `Tenant not usable (status=${tenant.status}, isActive=${tenant.isActive})`,
+        };
+      }
+    } else if (authMode === 'none') {
+      // A row with neither a delegated token nor a tenant mapping can't own or recreate a sub.
+      return { ...withIds, status: UserHealthStatus.NOT_MAPPED, reason: 'No delegated token and no tenant mapping' };
+    }
+
+    // Subscription checks.
+    if (!sub) {
+      return { ...withIds, status: UserHealthStatus.NO_SUBSCRIPTION, recoverable: true, reason: 'No active subscription' };
+    }
+    if (new Date(sub.expirationDateTime).getTime() <= Date.now()) {
+      return {
+        ...withIds,
+        status: UserHealthStatus.SUBSCRIPTION_EXPIRED,
+        recoverable: true,
+        subscriptionId: sub.subscriptionId,
+        reason: 'Subscription expired',
+      };
+    }
+    if (this.isStale(sub)) {
+      return {
+        ...withIds,
+        status: UserHealthStatus.SUBSCRIPTION_STALE,
+        recoverable: true,
+        subscriptionId: sub.subscriptionId,
+        reason: `No notification in over ${this.STALE_HOURS}h`,
+      };
+    }
+
+    return { ...withIds, connected: true, status: UserHealthStatus.HEALTHY, subscriptionId: sub.subscriptionId };
+  }
+
+  /** Recreate the subscription for a recoverable user; report the rest. Never throws. */
+  private async recoverOne(health: UserHealth, correlationId: string): Promise<UserHealthReport> {
+    if (health.status === UserHealthStatus.HEALTHY) {
+      return { ...health, action: 'none' };
+    }
+    if (!health.recoverable) {
+      return { ...health, action: 'reported' };
+    }
+
+    try {
+      let newSubscriptionId: string | undefined;
+      if (health.authMode === 'app-only' && health.tenantId && health.microsoftUserId) {
+        const created = await this.subscriptionService.createAppOnlyWebhookSubscription({
+          tenantId: health.tenantId,
+          microsoftUserId: health.microsoftUserId,
+          externalUserId: health.externalUserId,
+        });
+        newSubscriptionId = created.id ?? undefined;
+      } else {
+        const created = await this.subscriptionService.createWebhookSubscription(health.externalUserId);
+        newSubscriptionId = created.id ?? undefined;
+      }
+
+      return {
+        ...health,
+        connected: true,
+        status: UserHealthStatus.HEALTHY,
+        action: 'recreated',
+        newSubscriptionId,
+      };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unknown error';
+      this.logger.warn(`[${correlationId}] Recovery failed for ${health.externalUserId}: ${message}`);
+      return { ...health, action: 'recovery_failed', recoveryError: message };
+    }
+  }
+
+  /** app-only when mapped into a tenant; delegated when it holds a refresh token; else none. */
+  private authModeOf(user: MicrosoftUser): UserAuthMode {
+    if (user.microsoftUserId && user.tenant) {
+      return 'app-only';
+    }
+    if (user.refreshToken) {
+      return 'delegated';
+    }
+    return 'none';
+  }
+
+  /**
+   * Stale = no notification since {@link STALE_HOURS} ago. A subscription that has never received
+   * a notification uses its creation time as the reference, so freshly created subs aren't flagged.
+   */
+  private isStale(sub: OutlookWebhookSubscription): boolean {
+    const reference = sub.lastNotificationAt ?? sub.createdAt;
+    const threshold = Date.now() - this.STALE_HOURS * 60 * 60 * 1000;
+    return new Date(reference).getTime() < threshold;
+  }
+
+  /** Map userId → its active calendar subscription (resource ends in `/events`), if any. */
+  private indexCalendarSubscriptions(
+    subs: OutlookWebhookSubscription[],
+  ): Map<number, OutlookWebhookSubscription> {
+    const byUser = new Map<number, OutlookWebhookSubscription>();
+    for (const sub of subs) {
+      if (sub.resource.endsWith('/events') && !byUser.has(sub.userId)) {
+        byUser.set(sub.userId, sub);
+      }
+    }
+    return byUser;
+  }
+}

--- a/src/services/subscription/microsoft-subscription.service.spec.ts
+++ b/src/services/subscription/microsoft-subscription.service.spec.ts
@@ -69,6 +69,7 @@ describe('MicrosoftSubscriptionService - App-Only Methods', () => {
       findBySubscriptionId: jest.fn(),
       updateSubscriptionExpiration: jest.fn(),
       deactivateSubscription: jest.fn(),
+      deactivateAllByTenantId: jest.fn().mockResolvedValue(0),
       findAllActiveByTenantId: jest.fn(),
       findActiveByTenantAndMicrosoftUser: jest.fn(),
       findActiveSubscriptions: jest.fn(),
@@ -322,7 +323,14 @@ describe('MicrosoftSubscriptionService - App-Only Methods', () => {
   });
 
   describe('deleteAllAppOnlySubscriptionsForTenant', () => {
-    it('should delete all subscriptions for a tenant', async () => {
+    // Build a Graph $batch response body for the given per-request HTTP statuses.
+    const batchResponse = (statuses: number[]) => ({
+      data: {
+        responses: statuses.map((status, i) => ({ id: `${i}`, status, body: null })),
+      },
+    });
+
+    it('deletes all subscriptions via $batch and bulk-deactivates locally', async () => {
       const mockSubscriptions: Partial<OutlookWebhookSubscription>[] = [
         { subscriptionId: 'sub-1', tenantId: testTenantId, microsoftUserId: 'user-1' },
         { subscriptionId: 'sub-2', tenantId: testTenantId, microsoftUserId: 'user-2' },
@@ -332,18 +340,57 @@ describe('MicrosoftSubscriptionService - App-Only Methods', () => {
       mockWebhookRepo.findAllActiveByTenantId.mockResolvedValueOnce(
         mockSubscriptions as OutlookWebhookSubscription[],
       );
-      mockedAxios.delete.mockResolvedValue({ status: 204 });
+      mockedAxios.post.mockResolvedValueOnce(batchResponse([204, 204, 204]));
+      mockWebhookRepo.deactivateAllByTenantId.mockResolvedValueOnce(3);
 
       const result = await service.deleteAllAppOnlySubscriptionsForTenant(testTenantId);
 
       expect(mockWebhookRepo.findAllActiveByTenantId).toHaveBeenCalledWith(testTenantId);
       expect(mockAppOnlyAuthService.getAccessToken).toHaveBeenCalledWith(testTenantId);
 
-      // Verify all subscriptions were processed
+      // One $batch call, not one DELETE per subscription.
+      expect(mockedAxios.post).toHaveBeenCalledTimes(1);
+      expect(mockedAxios.post).toHaveBeenCalledWith(
+        'https://graph.microsoft.com/v1.0/$batch',
+        expect.objectContaining({
+          requests: expect.arrayContaining([
+            expect.objectContaining({ method: 'DELETE', url: '/subscriptions/sub-1' }),
+          ]),
+        }),
+        expect.objectContaining({
+          headers: expect.objectContaining({ Authorization: `Bearer ${testAccessToken}` }),
+        }),
+      );
+
+      // Local rows deactivated in ONE statement, not per-subscription.
+      expect(mockWebhookRepo.deactivateAllByTenantId).toHaveBeenCalledWith(testTenantId);
+      expect(mockWebhookRepo.deactivateSubscription).not.toHaveBeenCalled();
+
       expect(result.totalFound).toBe(3);
       expect(result.successfullyDeleted).toBe(3);
       expect(result.failedToDelete).toBe(0);
       expect(result.deletedSubscriptionIds).toEqual(['sub-1', 'sub-2', 'sub-3']);
+    });
+
+    it('chunks into batches of 20 (Graph limit)', async () => {
+      const mockSubscriptions = Array.from({ length: 45 }, (_, i) => ({
+        subscriptionId: `sub-${i}`,
+        tenantId: testTenantId,
+      })) as OutlookWebhookSubscription[];
+
+      mockWebhookRepo.findAllActiveByTenantId.mockResolvedValueOnce(mockSubscriptions);
+      mockedAxios.post
+        .mockResolvedValueOnce(batchResponse(new Array(20).fill(204)))
+        .mockResolvedValueOnce(batchResponse(new Array(20).fill(204)))
+        .mockResolvedValueOnce(batchResponse(new Array(5).fill(204)));
+      mockWebhookRepo.deactivateAllByTenantId.mockResolvedValueOnce(45);
+
+      const result = await service.deleteAllAppOnlySubscriptionsForTenant(testTenantId);
+
+      // 45 subs → 3 batch calls (20 + 20 + 5), not 45 individual deletes.
+      expect(mockedAxios.post).toHaveBeenCalledTimes(3);
+      expect(result.successfullyDeleted).toBe(45);
+      expect(mockWebhookRepo.deactivateAllByTenantId).toHaveBeenCalledWith(testTenantId);
     });
 
     it('should return empty result when no subscriptions exist', async () => {
@@ -354,9 +401,11 @@ describe('MicrosoftSubscriptionService - App-Only Methods', () => {
       expect(result.totalFound).toBe(0);
       expect(result.successfullyDeleted).toBe(0);
       expect(result.deletedSubscriptionIds).toEqual([]);
+      expect(mockedAxios.post).not.toHaveBeenCalled();
+      expect(mockWebhookRepo.deactivateAllByTenantId).not.toHaveBeenCalled();
     });
 
-    it('should continue processing when some deletions fail', async () => {
+    it('records per-item failures from the batch and still bulk-deactivates', async () => {
       const mockSubscriptions: Partial<OutlookWebhookSubscription>[] = [
         { subscriptionId: 'sub-1', tenantId: testTenantId },
         { subscriptionId: 'sub-2', tenantId: testTenantId },
@@ -365,21 +414,22 @@ describe('MicrosoftSubscriptionService - App-Only Methods', () => {
       mockWebhookRepo.findAllActiveByTenantId.mockResolvedValueOnce(
         mockSubscriptions as OutlookWebhookSubscription[],
       );
-
-      // First succeeds, second fails with non-retryable error (403)
-      const nonRetryableError = createAxiosError(403, { error: 'Forbidden' });
-      mockedAxios.delete
-        .mockResolvedValueOnce({ status: 204 })
-        .mockRejectedValueOnce(nonRetryableError);
+      // sub-1 deleted (204), sub-2 fails (403).
+      mockedAxios.post.mockResolvedValueOnce(batchResponse([204, 403]));
+      mockWebhookRepo.deactivateAllByTenantId.mockResolvedValueOnce(2);
 
       const result = await service.deleteAllAppOnlySubscriptionsForTenant(testTenantId);
 
       expect(result.totalFound).toBe(2);
-      // Both get deactivated locally (one via delete, one via error handler)
-      expect(result.deletedSubscriptionIds.length).toBeGreaterThanOrEqual(1);
+      expect(result.successfullyDeleted).toBe(1);
+      expect(result.failedToDelete).toBe(1);
+      expect(result.deletedSubscriptionIds).toEqual(['sub-1']);
+      expect(result.errors[0].subscriptionId).toBe('sub-2');
+      // Local rows still deactivated regardless of Microsoft outcome.
+      expect(mockWebhookRepo.deactivateAllByTenantId).toHaveBeenCalledWith(testTenantId);
     });
 
-    it('should deactivate locally when token acquisition fails', async () => {
+    it('deactivates locally only when token acquisition fails (no batch call)', async () => {
       const mockSubscriptions: Partial<OutlookWebhookSubscription>[] = [
         { subscriptionId: 'sub-1', tenantId: testTenantId },
       ];
@@ -390,11 +440,12 @@ describe('MicrosoftSubscriptionService - App-Only Methods', () => {
       mockAppOnlyAuthService.getAccessToken.mockRejectedValueOnce(
         new Error('Token acquisition failed'),
       );
+      mockWebhookRepo.deactivateAllByTenantId.mockResolvedValueOnce(1);
 
       const result = await service.deleteAllAppOnlySubscriptionsForTenant(testTenantId);
 
-      // Should still deactivate locally
-      expect(mockWebhookRepo.deactivateSubscription).toHaveBeenCalledWith('sub-1');
+      expect(mockedAxios.post).not.toHaveBeenCalled();
+      expect(mockWebhookRepo.deactivateAllByTenantId).toHaveBeenCalledWith(testTenantId);
       expect(result.localOnlyDeactivated).toBe(1);
       expect(result.successfullyDeleted).toBe(0);
     });

--- a/src/services/subscription/microsoft-subscription.service.spec.ts
+++ b/src/services/subscription/microsoft-subscription.service.spec.ts
@@ -40,9 +40,12 @@ describe('MicrosoftSubscriptionService - App-Only Methods', () => {
   let service: MicrosoftSubscriptionService;
   let mockWebhookRepo: jest.Mocked<OutlookWebhookSubscriptionRepository>;
   let mockAppOnlyAuthService: jest.Mocked<AppOnlyAuthService>;
+  let mockMicrosoftAuthService: jest.Mocked<MicrosoftAuthService>;
   let mockUserIdConverter: jest.Mocked<UserIdConverterService>;
   let mockRateLimiter: jest.Mocked<GraphRateLimiterService>;
   let mockEventEmitter: jest.Mocked<EventEmitter2>;
+
+  const testDelegatedToken = 'delegated-user-token-abc';
 
   const mockConfig: MicrosoftOutlookConfig = {
     clientId: 'test-client-id',
@@ -73,6 +76,7 @@ describe('MicrosoftSubscriptionService - App-Only Methods', () => {
       findActiveByTenantAndMicrosoftUser: jest.fn(),
       findActiveSubscriptions: jest.fn(),
       findActiveByUserId: jest.fn(),
+      findAllActiveByUserId: jest.fn().mockResolvedValue([]),
     } as unknown as jest.Mocked<OutlookWebhookSubscriptionRepository>;
 
     mockAppOnlyAuthService = {
@@ -93,8 +97,11 @@ describe('MicrosoftSubscriptionService - App-Only Methods', () => {
       emit: jest.fn(),
     } as unknown as jest.Mocked<EventEmitter2>;
 
-    // Create mock MicrosoftAuthService (not used in app-only methods but required)
-    const mockMicrosoftAuthService = {} as unknown as MicrosoftAuthService;
+    // MicrosoftAuthService — supplies the user's delegated token for delegated create
+    // and for deleting a stale delegated subscription during the dedup guard.
+    mockMicrosoftAuthService = {
+      getUserAccessToken: jest.fn().mockResolvedValue(testDelegatedToken),
+    } as unknown as jest.Mocked<MicrosoftAuthService>;
 
     // Create mock MicrosoftUser repository
     const mockMicrosoftUserRepo = {
@@ -452,6 +459,145 @@ describe('MicrosoftSubscriptionService - App-Only Methods', () => {
 
       expect(mockWebhookRepo.findAllActiveByTenantId).toHaveBeenCalledWith(testTenantId);
       expect(result).toHaveLength(2);
+    });
+  });
+
+  describe('duplicate calendar subscription guard', () => {
+    const buildSub = (overrides: Partial<OutlookWebhookSubscription>): OutlookWebhookSubscription =>
+      ({
+        id: 1,
+        subscriptionId: 'old-sub',
+        userId: testInternalUserId,
+        resource: '/me/events',
+        tenantId: null,
+        microsoftUserId: null,
+        isActive: true,
+        ...overrides,
+      }) as OutlookWebhookSubscription;
+
+    const appOnlyGraphResponse = {
+      data: {
+        id: testSubscriptionId,
+        resource: `/users/${testMicrosoftUserId}/events`,
+        changeType: 'created,updated,deleted',
+        clientState: `tenant_${testTenantId}_user_${testInternalUserId}_uuid`,
+        notificationUrl: 'https://api.example.com/api/v1/calendar/webhook',
+        expirationDateTime: new Date(Date.now() + 72 * 60 * 60 * 1000).toISOString(),
+      },
+    };
+
+    const appOnlyOptions: AppOnlySubscriptionOptions = {
+      tenantId: testTenantId,
+      microsoftUserId: testMicrosoftUserId,
+      externalUserId: testExternalUserId,
+      internalUserId: testInternalUserId,
+    };
+
+    it('app-only create removes a pre-existing delegated calendar subscription', async () => {
+      mockWebhookRepo.findAllActiveByUserId.mockResolvedValueOnce([
+        buildSub({ subscriptionId: 'old-delegated', resource: '/me/events', tenantId: null }),
+      ]);
+      mockedAxios.delete.mockResolvedValueOnce({ data: {} });
+      mockedAxios.post.mockResolvedValueOnce(appOnlyGraphResponse);
+      mockWebhookRepo.saveSubscription.mockResolvedValueOnce({ id: 2 } as OutlookWebhookSubscription);
+
+      await service.createAppOnlyWebhookSubscription(appOnlyOptions);
+
+      // Deleted the stale delegated sub with the USER's delegated token.
+      expect(mockMicrosoftAuthService.getUserAccessToken).toHaveBeenCalledWith(
+        expect.objectContaining({ internalUserId: testInternalUserId, includeInactive: true }),
+      );
+      expect(mockedAxios.delete).toHaveBeenCalledWith(
+        expect.stringContaining('/subscriptions/old-delegated'),
+        expect.objectContaining({
+          headers: expect.objectContaining({ Authorization: `Bearer ${testDelegatedToken}` }),
+        }),
+      );
+      expect(mockWebhookRepo.deactivateSubscription).toHaveBeenCalledWith('old-delegated');
+      // New app-only sub still created.
+      expect(mockWebhookRepo.saveSubscription).toHaveBeenCalledWith(
+        expect.objectContaining({ subscriptionId: testSubscriptionId, tenantId: testTenantId }),
+      );
+    });
+
+    it('delegated create removes a pre-existing app-only calendar subscription', async () => {
+      mockWebhookRepo.findAllActiveByUserId.mockResolvedValueOnce([
+        buildSub({
+          subscriptionId: 'old-apponly',
+          resource: `/users/${testMicrosoftUserId}/events`,
+          tenantId: testTenantId,
+          microsoftUserId: testMicrosoftUserId,
+        }),
+      ]);
+      mockedAxios.delete.mockResolvedValueOnce({ data: {} });
+      mockedAxios.post.mockResolvedValueOnce({
+        data: {
+          id: testSubscriptionId,
+          resource: '/me/events',
+          changeType: 'created,updated,deleted',
+          clientState: `user_${testInternalUserId}_uuid`,
+          notificationUrl: 'https://api.example.com/api/v1/calendar/webhook',
+          expirationDateTime: new Date(Date.now() + 72 * 60 * 60 * 1000).toISOString(),
+        },
+      });
+      mockWebhookRepo.saveSubscription.mockResolvedValueOnce({ id: 3 } as OutlookWebhookSubscription);
+
+      await service.createWebhookSubscription(testExternalUserId);
+
+      // Deleted the stale app-only sub with the tenant's APP-ONLY token.
+      expect(mockAppOnlyAuthService.getAccessToken).toHaveBeenCalledWith(testTenantId);
+      expect(mockedAxios.delete).toHaveBeenCalledWith(
+        expect.stringContaining('/subscriptions/old-apponly'),
+        expect.objectContaining({
+          headers: expect.objectContaining({ Authorization: `Bearer ${testAccessToken}` }),
+        }),
+      );
+      expect(mockWebhookRepo.deactivateSubscription).toHaveBeenCalledWith('old-apponly');
+      // New delegated sub still created.
+      expect(mockWebhookRepo.saveSubscription).toHaveBeenCalled();
+    });
+
+    it('leaves email subscriptions untouched', async () => {
+      mockWebhookRepo.findAllActiveByUserId.mockResolvedValueOnce([
+        buildSub({ subscriptionId: 'email-sub', resource: '/me/messages', tenantId: null }),
+      ]);
+      mockedAxios.post.mockResolvedValueOnce(appOnlyGraphResponse);
+      mockWebhookRepo.saveSubscription.mockResolvedValueOnce({ id: 4 } as OutlookWebhookSubscription);
+
+      await service.createAppOnlyWebhookSubscription(appOnlyOptions);
+
+      expect(mockedAxios.delete).not.toHaveBeenCalled();
+      expect(mockWebhookRepo.deactivateSubscription).not.toHaveBeenCalledWith('email-sub');
+    });
+
+    it('is best-effort: still creates the new sub when deleting the old one fails', async () => {
+      mockWebhookRepo.findAllActiveByUserId.mockResolvedValueOnce([
+        buildSub({ subscriptionId: 'old-delegated', resource: '/me/events', tenantId: null }),
+      ]);
+      // No token available for the stale delegated sub — MS delete is skipped.
+      mockMicrosoftAuthService.getUserAccessToken.mockRejectedValueOnce(new Error('token gone'));
+      mockedAxios.post.mockResolvedValueOnce(appOnlyGraphResponse);
+      mockWebhookRepo.saveSubscription.mockResolvedValueOnce({ id: 5 } as OutlookWebhookSubscription);
+
+      await expect(service.createAppOnlyWebhookSubscription(appOnlyOptions)).resolves.toBeDefined();
+
+      expect(mockedAxios.delete).not.toHaveBeenCalled();
+      // Local deactivation still happens so the row stops counting as active.
+      expect(mockWebhookRepo.deactivateSubscription).toHaveBeenCalledWith('old-delegated');
+      // New sub created despite the failed cleanup.
+      expect(mockWebhookRepo.saveSubscription).toHaveBeenCalled();
+    });
+
+    it('creates normally when there are no existing subscriptions', async () => {
+      mockWebhookRepo.findAllActiveByUserId.mockResolvedValueOnce([]);
+      mockedAxios.post.mockResolvedValueOnce(appOnlyGraphResponse);
+      mockWebhookRepo.saveSubscription.mockResolvedValueOnce({ id: 6 } as OutlookWebhookSubscription);
+
+      await service.createAppOnlyWebhookSubscription(appOnlyOptions);
+
+      expect(mockedAxios.delete).not.toHaveBeenCalled();
+      expect(mockWebhookRepo.deactivateSubscription).not.toHaveBeenCalled();
+      expect(mockWebhookRepo.saveSubscription).toHaveBeenCalled();
     });
   });
 });

--- a/src/services/subscription/microsoft-subscription.service.ts
+++ b/src/services/subscription/microsoft-subscription.service.ts
@@ -242,6 +242,110 @@ export class MicrosoftSubscriptionService {
     }
   }
 
+  /**
+   * Classify a stored subscription resource path as a calendar resource. Both delegated
+   * (`/me/events`) and app-only (`/users/{id}/events`) calendar subscriptions end in
+   * `/events`; email resources end in `/messages`.
+   */
+  private isCalendarResource(resource: string | null | undefined): boolean {
+    return typeof resource === 'string' && resource.endsWith('/events');
+  }
+
+  /**
+   * Remove any already-active CALENDAR webhook subscription for a user before a new one
+   * is created, so a mailbox never has two live calendar subscriptions firing duplicate
+   * notifications.
+   *
+   * Runs across BOTH auth modes, keyed by the shared internal `userId` on every
+   * subscription row: a delegated user who joins a tenant (app-only create) has their old
+   * `/me/events` sub removed, and an app-only-mapped user who later connects delegated has
+   * their old `/users/{id}/events` sub removed.
+   *
+   * Best-effort: each stale sub is deleted at Microsoft with the token matching the
+   * subscription's own auth mode (app-only token when `tenantId` is set, the user's
+   * delegated token otherwise) and always deactivated locally. A missing token or a failed
+   * Graph delete is logged and the row is still deactivated — the guard never throws, so it
+   * cannot block creation of the new subscription.
+   *
+   * Uses the low-level `deleteSubscription` + `deactivateSubscription` rather than
+   * `deleteWebhookSubscription`, deliberately skipping the user-lifecycle side effect that
+   * would mark the user inactive when their "last" subscription is removed.
+   *
+   * @param internalUserId - Internal MicrosoftUser id shared by all of the user's subs.
+   * @param correlationId - Correlation id from the calling create flow, for log tracing.
+   */
+  private async removeExistingCalendarSubscriptionsForUser(
+    internalUserId: number,
+    correlationId: string,
+  ): Promise<void> {
+    try {
+      const active = await this.webhookSubscriptionRepository.findAllActiveByUserId(internalUserId);
+      const staleCalendarSubs = active.filter((sub) => this.isCalendarResource(sub.resource));
+
+      if (staleCalendarSubs.length === 0) {
+        return;
+      }
+
+      this.logger.log(
+        `[${correlationId}] Removing ${staleCalendarSubs.length} existing calendar ` +
+        `subscription(s) for user ${internalUserId} before creating a new one`,
+      );
+
+      // Tiny per-user set — process sequentially; deleteSubscription carries its own 429
+      // backoff/retry so we stay within Graph rate limits.
+      for (const sub of staleCalendarSubs) {
+        try {
+          let accessToken: string | null = null;
+          if (sub.tenantId) {
+            // App-only subscription — delete with the tenant's app-only token.
+            accessToken = this.appOnlyAuthService
+              ? await this.appOnlyAuthService.getAccessToken(sub.tenantId)
+              : null;
+          } else {
+            // Delegated subscription — delete with the user's delegated token.
+            accessToken = await this.microsoftAuthService.getUserAccessToken({
+              internalUserId,
+              includeInactive: true,
+              cache: false,
+            });
+          }
+
+          if (accessToken) {
+            await this.deleteSubscription(sub.subscriptionId, accessToken);
+          } else {
+            this.logger.warn(
+              `[${correlationId}] No token available to delete subscription ` +
+              `${sub.subscriptionId} at Microsoft; deactivating locally only`,
+            );
+          }
+        } catch (error) {
+          this.logger.warn(
+            `[${correlationId}] Failed to delete existing subscription ${sub.subscriptionId} ` +
+            `at Microsoft: ${error instanceof Error ? error.message : 'Unknown error'}. ` +
+            `Deactivating locally.`,
+          );
+        } finally {
+          // Always drop the local row so it stops being treated as active, even if the
+          // Microsoft-side delete failed (the sub expires there within ≤3 days).
+          try {
+            await this.webhookSubscriptionRepository.deactivateSubscription(sub.subscriptionId);
+          } catch (deactivateError) {
+            this.logger.warn(
+              `[${correlationId}] Failed to deactivate subscription ${sub.subscriptionId} ` +
+              `locally: ${deactivateError instanceof Error ? deactivateError.message : 'Unknown error'}`,
+            );
+          }
+        }
+      }
+    } catch (error) {
+      // Never let dedup block a fresh subscription — log and continue.
+      this.logger.warn(
+        `[${correlationId}] Error while removing existing calendar subscriptions for user ` +
+        `${internalUserId}: ${error instanceof Error ? error.message : 'Unknown error'}`,
+      );
+    }
+  }
+
   // ─── Webhook subscription lifecycle ─────────────────────────────────
 
   /**
@@ -257,6 +361,10 @@ export class MicrosoftSubscriptionService {
 
     const correlationId = `webhook-${internalUserId}-${Date.now()}`;
     this.logger.log(`[${correlationId}] Starting webhook subscription creation for user ${internalUserId}`);
+
+    // Drop any existing calendar subscription for this user (e.g. an app-only sub from a
+    // prior tenant mapping) so the mailbox isn't double-subscribed. Best-effort, never throws.
+    await this.removeExistingCalendarSubscriptionsForUser(internalUserId, correlationId);
 
     try {
       // Get a valid access token for this user
@@ -1509,6 +1617,10 @@ export class MicrosoftSubscriptionService {
       if (internalUserId === undefined) {
         internalUserId = await this.userIdConverter.externalToInternal(externalUserId, { cache: false });
       }
+
+      // Drop any existing calendar subscription for this user (e.g. a delegated /me/events
+      // sub) so the mailbox isn't double-subscribed after joining the tenant. Best-effort.
+      await this.removeExistingCalendarSubscriptionsForUser(internalUserId, correlationId);
 
       // Get app-only access token for the tenant
       const accessToken = await this.appOnlyAuthService.getAccessToken(tenantId);

--- a/src/services/subscription/microsoft-subscription.service.ts
+++ b/src/services/subscription/microsoft-subscription.service.ts
@@ -243,6 +243,63 @@ export class MicrosoftSubscriptionService {
   }
 
   /**
+   * Verify a stored subscription still exists at Microsoft Graph, using the token that matches
+   * the subscription's own auth mode: the tenant's app-only token when `tenantId` is set, the
+   * owning user's delegated token otherwise. Used by the health service for `verifyAtGraph`.
+   *
+   * @param subscription - The stored subscription (needs `subscriptionId`, `userId`, `tenantId`).
+   * @returns `'present'` (still there), `'missing'` (404 / gone), or `'unknown'` (token or Graph
+   *   error — treat as inconclusive, don't act on it).
+   */
+  async verifySubscriptionAtGraph(
+    subscription: Pick<OutlookWebhookSubscription, 'subscriptionId' | 'userId' | 'tenantId'>,
+  ): Promise<'present' | 'missing' | 'unknown'> {
+    try {
+      let accessToken: string | null = null;
+      if (subscription.tenantId) {
+        accessToken = this.appOnlyAuthService
+          ? await this.appOnlyAuthService.getAccessToken(subscription.tenantId)
+          : null;
+      } else {
+        accessToken = await this.microsoftAuthService.getUserAccessToken({
+          internalUserId: subscription.userId,
+          includeInactive: true,
+          cache: false,
+        });
+      }
+
+      if (!accessToken) {
+        return 'unknown';
+      }
+
+      const response = await executeGraphApiCall(
+        () => axios.get(`${this.graphApiBaseUrl}/subscriptions/${subscription.subscriptionId}`, {
+          headers: {
+            Authorization: `Bearer ${accessToken}`,
+            'Prefer': 'IdType="ImmutableId"',
+          },
+          timeout: 10000,
+        }),
+        {
+          logger: this.logger,
+          resourceName: `verify subscription ${subscription.subscriptionId}`,
+          maxRetries: 3,
+          return404AsNull: true,
+        }
+      );
+
+      return response ? 'present' : 'missing';
+    } catch (error) {
+      this.logger.warn(
+        `[verifySubscriptionAtGraph] Could not verify subscription ${subscription.subscriptionId}: ${
+          error instanceof Error ? error.message : 'Unknown error'
+        }`,
+      );
+      return 'unknown';
+    }
+  }
+
+  /**
    * Classify a stored subscription resource path as a calendar resource. Both delegated
    * (`/me/events`) and app-only (`/users/{id}/events`) calendar subscriptions end in
    * `/events`; email resources end in `/messages`.

--- a/src/services/subscription/microsoft-subscription.service.ts
+++ b/src/services/subscription/microsoft-subscription.service.ts
@@ -1831,7 +1831,8 @@ export class MicrosoftSubscriptionService {
         `[${correlationId}] Found ${activeSubscriptions.length} active subscription(s) to delete`
       );
 
-      // Try to get access token
+      // Try to get an app-only token so we can delete at Microsoft. If unavailable, we still
+      // deactivate everything locally below (the subs expire at Microsoft within ≤3 days).
       let accessToken: string | null = null;
       if (this.appOnlyAuthService) {
         try {
@@ -1846,62 +1847,39 @@ export class MicrosoftSubscriptionService {
         }
       }
 
-      // Process each subscription
-      for (const subscription of activeSubscriptions) {
-        const subId = subscription.subscriptionId;
-
-        try {
-          // Try to delete at Microsoft if we have a token
-          if (accessToken) {
-            try {
-              await this.deleteSubscription(subId, accessToken);
-              this.logger.debug(
-                `[${correlationId}] Deleted subscription ${subId} at Microsoft`
-              );
-            } catch (deleteError) {
-              // Handle 404 gracefully (subscription already gone)
-              if (axios.isAxiosError(deleteError) && deleteError.response?.status === 404) {
-                this.logger.debug(
-                  `[${correlationId}] Subscription ${subId} not found at Microsoft (already deleted)`
-                );
-              } else {
-                const deleteErrorMsg = deleteError instanceof Error ? deleteError.message : 'Unknown error';
-                this.logger.warn(
-                  `[${correlationId}] Failed to delete subscription ${subId} at Microsoft: ${deleteErrorMsg}`
-                );
-                result.errors.push({ subscriptionId: subId, error: deleteErrorMsg });
-              }
-            }
-          }
-
-          // Always deactivate locally
-          await this.webhookSubscriptionRepository.deactivateSubscription(subId);
-
-          if (accessToken) {
+      if (accessToken) {
+        // Delete at Microsoft in batches of 20 (Graph $batch limit) — ~20x fewer round-trips
+        // than one DELETE per subscription, and each batch respects retry/429 backoff.
+        const subscriptionIds = activeSubscriptions.map((s) => s.subscriptionId);
+        const batchResults = await this.deleteSubscriptionsBatch(
+          subscriptionIds,
+          accessToken,
+          correlationId
+        );
+        for (const item of batchResults) {
+          if (item.success) {
             result.successfullyDeleted++;
+            result.deletedSubscriptionIds.push(item.id);
           } else {
-            result.localOnlyDeactivated++;
+            result.failedToDelete++;
+            result.errors.push({ subscriptionId: item.id, error: item.error ?? 'Unknown error' });
           }
-          result.deletedSubscriptionIds.push(subId);
-
-          this.logger.debug(
-            `[${correlationId}] Deactivated subscription ${subId} in local database`
-          );
-        } catch (error) {
-          const errorMsg = error instanceof Error ? error.message : 'Unknown error';
-          result.failedToDelete++;
-          result.errors.push({ subscriptionId: subId, error: errorMsg });
-          this.logger.error(
-            `[${correlationId}] Failed to process subscription ${subId}: ${errorMsg}`
-          );
         }
+      } else {
+        result.localOnlyDeactivated = activeSubscriptions.length;
       }
+
+      // Deactivate every local row for this tenant in ONE statement, regardless of the
+      // per-item Microsoft outcome — after a disconnect these rows must not stay active.
+      const deactivatedCount = await this.webhookSubscriptionRepository.deactivateAllByTenantId(
+        tenantId
+      );
 
       this.logger.log(
         `[${correlationId}] Bulk deletion complete for tenant ${tenantId}: ` +
         `${result.successfullyDeleted} deleted at Microsoft, ` +
         `${result.localOnlyDeactivated} deactivated locally only, ` +
-        `${result.failedToDelete} failed.`
+        `${result.failedToDelete} failed; ${deactivatedCount} local row(s) deactivated.`
       );
 
       return result;
@@ -1912,5 +1890,106 @@ export class MicrosoftSubscriptionService {
       );
       throw new Error(`Failed to delete all app-only webhook subscriptions: ${errorMessage}`);
     }
+  }
+
+  /**
+   * Delete subscriptions at Microsoft Graph using the `/$batch` endpoint (max 20 per call).
+   *
+   * Batches are sent sequentially so we never burst the Graph API; each batch goes through
+   * `executeGraphApiCall` for retry/429 backoff. A `204` (deleted) or `404` (already gone)
+   * counts as success. Results are correlated to subscription IDs by the per-request `id`,
+   * so an out-of-order batch response is still matched to the right subscription.
+   *
+   * @param subscriptionIds - Microsoft subscription IDs to delete.
+   * @param accessToken - App-only access token for the tenant.
+   * @param correlationId - Correlation id for log tracing.
+   * @returns Per-subscription success/failure (order not guaranteed).
+   */
+  private async deleteSubscriptionsBatch(
+    subscriptionIds: string[],
+    accessToken: string,
+    correlationId: string,
+  ): Promise<{ id: string; success: boolean; error?: string }[]> {
+    const results: { id: string; success: boolean; error?: string }[] = [];
+    const BATCH_SIZE = 20;
+
+    for (let i = 0; i < subscriptionIds.length; i += BATCH_SIZE) {
+      const chunk = subscriptionIds.slice(i, i + BATCH_SIZE);
+      // Map the per-request id (index within the chunk) back to the subscription id.
+      const subIdByRequestId = new Map<string, string>();
+
+      const batchPayload: BatchRequestPayload = {
+        requests: chunk.map((subscriptionId, index) => {
+          subIdByRequestId.set(`${index}`, subscriptionId);
+          return {
+            id: `${index}`,
+            method: 'DELETE',
+            url: `/subscriptions/${subscriptionId}`,
+          };
+        }),
+      };
+
+      this.logger.log(
+        `[${correlationId}] Deleting batch of ${chunk.length} subscription(s) at Microsoft`
+      );
+
+      try {
+        const response = await executeGraphApiCall(
+          () => axios.post<BatchResponsePayload>(
+            'https://graph.microsoft.com/v1.0/$batch',
+            batchPayload,
+            {
+              headers: {
+                Authorization: `Bearer ${accessToken}`,
+                'Content-Type': 'application/json',
+              },
+            }
+          ),
+          {
+            logger: this.logger,
+            resourceName: `batch delete ${chunk.length} subscriptions`,
+            maxRetries: 7,
+          }
+        );
+
+        const batchResponse = response?.data;
+        if (!batchResponse) {
+          throw new Error('Batch request returned null response');
+        }
+
+        for (const item of batchResponse.responses) {
+          const subscriptionId = subIdByRequestId.get(item.id) ?? item.id;
+          // 200/204 = deleted, 404 = already gone — all treated as success.
+          if (item.status === 200 || item.status === 204 || item.status === 404) {
+            results.push({ id: subscriptionId, success: true });
+          } else {
+            const errorMessage = item.body ? JSON.stringify(item.body) : `HTTP ${item.status}`;
+            results.push({
+              id: subscriptionId,
+              success: false,
+              error: `HTTP ${item.status}: ${errorMessage}`,
+            });
+            this.logger.warn(
+              `[${correlationId}] Failed to delete subscription ${subscriptionId} at Microsoft: ${errorMessage}`
+            );
+          }
+        }
+      } catch (error) {
+        // Whole batch failed — mark every subscription in this chunk as failed at Graph.
+        const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+        this.logger.warn(
+          `[${correlationId}] Batch delete request failed for ${chunk.length} subscription(s): ${errorMessage}`
+        );
+        for (const subscriptionId of chunk) {
+          results.push({
+            id: subscriptionId,
+            success: false,
+            error: `Batch request failed: ${errorMessage}`,
+          });
+        }
+      }
+    }
+
+    return results;
   }
 }

--- a/src/services/subscription/tenant-disconnect.chaos.spec.ts
+++ b/src/services/subscription/tenant-disconnect.chaos.spec.ts
@@ -1,0 +1,230 @@
+import { Logger } from '@nestjs/common';
+import axios from 'axios';
+import {
+  buildChaosWorld,
+  SeedUser,
+  AxiosMockLike,
+  installChaosTimers,
+  uninstallChaosTimers,
+  drain,
+  drainUntil,
+} from '../../mock/chaos';
+
+jest.mock('axios');
+const mockedAxios = axios as jest.Mocked<typeof axios> as unknown as AxiosMockLike;
+
+jest.setTimeout(120_000);
+
+/**
+ * Chaos + scale tests for the tenant disconnect/purge flow: batched subscription deletion at
+ * Graph, bulk local deactivation, user-mapping teardown with token revocation, and the
+ * 202-background controller contract — all against a disrupted Graph/DB.
+ */
+describe('Tenant disconnect (purge) — chaos at scale', () => {
+  const SEED = Number(process.env.CHAOS_SEED ?? 20260714);
+  const TENANT = 'tenant-t1-guid';
+
+  /** 450 app-only-only users + 150 dual (delegated tokens too), each with one app-only sub. */
+  const seedTenantUsers = (): SeedUser[] => [
+    ...Array.from({ length: 450 }, (_, i) => ({
+      externalUserId: `ao-${i}`,
+      email: `ao-${i}@contoso.com`,
+      kind: 'app-only' as const,
+      sub: { mode: 'app-only' as const },
+    })),
+    ...Array.from({ length: 150 }, (_, i) => ({
+      externalUserId: `dual-${i}`,
+      email: `dual-${i}@contoso.com`,
+      kind: 'dual' as const,
+      sub: { mode: 'app-only' as const },
+    })),
+  ];
+
+  beforeAll(() => {
+    Logger.overrideLogger(false);
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    installChaosTimers();
+  });
+
+  afterEach(() => {
+    uninstallChaosTimers();
+  });
+
+  it('baseline: 600 subscriptions deleted via $batch (30 calls, not 600) + ONE bulk deactivate', async () => {
+    const world = buildChaosWorld(mockedAxios, { seed: SEED, users: seedTenantUsers() });
+    const svc = world.services.subscriptionService;
+
+    const result = await drain(svc.deleteAllAppOnlySubscriptionsForTenant(TENANT));
+
+    expect(result).toMatchObject({ totalFound: 600, successfullyDeleted: 600, failedToDelete: 0 });
+    // Consumption: ceil(600/20) = 30 batch calls; zero per-subscription DELETEs.
+    expect(world.metrics.attemptsFor('batch')).toBe(30);
+    expect(world.metrics.attemptsFor('subs.delete')).toBe(0);
+    // Local teardown is ONE set-based statement, not 600 row updates.
+    expect(world.metrics.dbCallsFor('subs.deactivateAllByTenantId')).toBe(1);
+    expect(world.metrics.dbCallsFor('subs.deactivate')).toBe(0);
+
+    expect(world.db.subscriptions.filter((s) => s.tenantId === TENANT && s.isActive)).toHaveLength(0);
+    expect(world.graph.subscriptionIdsForResourcePrefix('/users/')).toHaveLength(0);
+
+    console.log(world.metrics.report(`purge baseline 600 subs seed=${SEED}`));
+  });
+
+  it('batch chaos: outer 429 retries + per-item failures — exact tallies, chunking stable, locals always deactivated', async () => {
+    const users = seedTenantUsers();
+    const world = buildChaosWorld(mockedAxios, { seed: SEED, users });
+    const svc = world.services.subscriptionService;
+
+    // First 3 whole-batch attempts are throttled (deterministic retries), then weather clears.
+    world.engine.failTimes('batch', '*', 3, 429);
+    // 50 subscriptions are genuinely "already gone" at Graph (drift → inner 404 = success),
+    // 30 hard-fail per item.
+    const dbSubs = world.db.subscriptions.filter((s) => s.tenantId === TENANT);
+    const goneIds = dbSubs.slice(0, 50).map((s) => s.subscriptionId);
+    const brokenIds = dbSubs.slice(50, 80).map((s) => s.subscriptionId);
+    for (const id of goneIds) world.graph.subscriptions.delete(id);
+    for (const id of brokenIds) world.engine.alwaysFail('batch.item', id, 500);
+
+    const result = await drain(svc.deleteAllAppOnlySubscriptionsForTenant(TENANT));
+
+    // 404s count as deleted; only the 30 hard failures are reported.
+    expect(result.successfullyDeleted).toBe(570);
+    expect(result.failedToDelete).toBe(30);
+    expect(result.successfullyDeleted + result.failedToDelete).toBe(result.totalFound);
+    expect(result.errors).toHaveLength(30);
+    expect(new Set(result.errors.map((e) => e.subscriptionId))).toEqual(new Set(brokenIds));
+    // Batch-response correlation: the reported deleted ids are exactly the non-broken set.
+    expect(result.deletedSubscriptionIds).toHaveLength(570);
+    const broken = new Set(brokenIds);
+    expect(result.deletedSubscriptionIds.every((id) => !broken.has(id))).toBe(true);
+    // Chunking stayed at 30 logical batches; the outer retries added exactly 3 attempts.
+    expect(world.metrics.attemptsFor('batch')).toBe(33);
+    // Local rows are ALL deactivated regardless of the per-item Graph outcome.
+    expect(world.db.subscriptions.filter((s) => s.tenantId === TENANT && s.isActive)).toHaveLength(0);
+    // The 30 broken ones remain at Graph (they truly were not deleted).
+    expect(world.graph.subscriptionIdsForResourcePrefix('/users/')).toHaveLength(30);
+
+    console.log(world.metrics.report(`purge batch-chaos seed=${SEED}`));
+  });
+
+  it('mapping teardown (default): dual rows unmapped keeping delegated login, app-only rows deleted — zero revocations', async () => {
+    const world = buildChaosWorld(mockedAxios, { seed: SEED, users: seedTenantUsers() });
+
+    const result = await drain(world.services.tenantUserService.clearTenantUserMappings(TENANT));
+
+    expect(result).toMatchObject({
+      delegatedRowsUnmapped: 150,
+      appOnlyRowsDeleted: 450,
+      tokensRevoked: 0,
+      tokenRevocationFailures: 0,
+    });
+    expect(world.metrics.attemptsFor('auth.revoke')).toBe(0);
+    // Consumption: the teardown is exactly one bulk UPDATE + one bulk DELETE, not 600 row ops.
+    expect(world.metrics.dbCallsFor('users.qb.update')).toBe(1);
+    expect(world.metrics.dbCallsFor('users.qb.delete')).toBe(1);
+    expect(world.metrics.dbCallsFor('users.save')).toBe(0);
+    // Dual users survive with delegated login intact and the app-only mapping stripped.
+    const dualRows = world.db.users.filter((u) => u.externalUserId.startsWith('dual-'));
+    expect(dualRows).toHaveLength(150);
+    for (const row of dualRows) {
+      expect(row.refreshToken).not.toBeNull();
+      expect(row.tenant).toBeNull();
+      expect(row.microsoftUserId).toBeNull();
+    }
+    expect(world.db.users.filter((u) => u.externalUserId.startsWith('ao-'))).toHaveLength(0);
+  });
+
+  it('revocation chaos: 150 tokens revoked single-shot at bounded concurrency; failures counted, teardown never aborts', async () => {
+    const world = buildChaosWorld(mockedAxios, {
+      seed: SEED,
+      users: seedTenantUsers(),
+      graphLatencyMs: { min: 1, max: 10 },
+    });
+
+    // 20 delegated tokens hard-fail at the logout endpoint.
+    const failingTokens = Array.from({ length: 20 }, (_, i) => `refresh-dual-${i}`);
+    for (const token of failingTokens) world.engine.alwaysFail('auth.revoke', token, 500);
+
+    const result = await drain(
+      world.services.tenantUserService.clearTenantUserMappings(TENANT, { revokeDelegatedTokens: true }),
+    );
+
+    expect(result.tokensRevoked).toBe(130);
+    expect(result.tokenRevocationFailures).toBe(20);
+    // Revocation is best-effort single-shot: exactly one attempt per token, no retry storm.
+    expect(world.metrics.attemptsFor('auth.revoke')).toBe(150);
+    for (const token of failingTokens) {
+      expect(world.metrics.attemptsForKey('auth.revoke', token)).toBe(1);
+    }
+    // Bounded concurrency at the revocation endpoint — parallel (>1) but capped at 5.
+    expect(world.metrics.peakInFlight).toBeLessThanOrEqual(5);
+    expect(world.metrics.peakInFlight).toBeGreaterThan(1);
+    // Aggressive path removes every tenant row despite the failures.
+    expect(result.appOnlyRowsDeleted).toBe(600);
+    expect(world.db.users).toHaveLength(0);
+
+    console.log(world.metrics.report(`revocation chaos seed=${SEED}`));
+  });
+
+  it('token unavailable: falls back to local-only deactivation with zero Graph traffic', async () => {
+    const world = buildChaosWorld(mockedAxios, { seed: SEED, users: seedTenantUsers() });
+    world.engine.alwaysFail('auth.appOnlyToken', TENANT, 500);
+
+    const result = await drain(world.services.subscriptionService.deleteAllAppOnlySubscriptionsForTenant(TENANT));
+
+    expect(result.localOnlyDeactivated).toBe(600);
+    expect(result.successfullyDeleted).toBe(0);
+    expect(world.metrics.attemptsFor('batch')).toBe(0);
+    expect(world.db.subscriptions.filter((s) => s.tenantId === TENANT && s.isActive)).toHaveLength(0);
+  });
+
+  it('host contract: soft disconnect (no purge) deactivates synchronously and touches NOTHING else', async () => {
+    const users = seedTenantUsers().slice(0, 80);
+    const world = buildChaosWorld(mockedAxios, { seed: SEED, users });
+
+    const response = await drain(world.controllers.tenantAuthController.disconnect(TENANT));
+
+    expect(response.message).toContain('disconnected successfully');
+    // Synchronous: the tenant is already inactive at response time.
+    expect(world.db.tenants.find((t) => t.tenantId === TENANT)?.isActive).toBe(false);
+    // Soft = zero Graph traffic, subscriptions and user mappings left fully intact.
+    expect(world.metrics.attempts.size).toBe(0);
+    expect(world.db.subscriptions.filter((s) => s.tenantId === TENANT && s.isActive)).toHaveLength(80);
+    expect(world.db.users.every((u) => u.tenant !== null)).toBe(true);
+  });
+
+  it('host contract: DELETE connection?purge=true returns 202-style before teardown; tenant deactivated LAST', async () => {
+    const users = seedTenantUsers().slice(0, 120);
+    const world = buildChaosWorld(mockedAxios, {
+      seed: SEED,
+      users,
+      graphLatencyMs: { min: 2, max: 15 },
+    });
+
+    const response = await world.controllers.tenantAuthController.disconnect(TENANT, 'true', 'false');
+
+    expect(response.message).toContain('background');
+    // At response time the teardown has not run: the tenant connection is still active.
+    const tenant = world.db.tenants.find((t) => t.tenantId === TENANT);
+    expect(tenant?.isActive).toBe(true);
+
+    await drainUntil(() => world.metrics.timeline.includes('tenant:deactivate'));
+
+    // Ordering: every Graph batch delete happened BEFORE the tenant was deactivated
+    // (the app-only token must stay valid during teardown), and the cache was dropped after.
+    // Guard against vacuity first: the purge really did delete at Graph.
+    const lastBatchAt = world.metrics.lastIndexOf('graph:batch');
+    expect(lastBatchAt).toBeGreaterThan(-1);
+    const deactivateAt = world.metrics.timeline.indexOf('tenant:deactivate');
+    expect(lastBatchAt).toBeLessThan(deactivateAt);
+    expect(world.metrics.timeline.indexOf('auth:invalidateCache')).toBeGreaterThan(deactivateAt);
+
+    expect(tenant?.isActive).toBe(false);
+    expect(world.db.subscriptions.filter((s) => s.tenantId === TENANT && s.isActive)).toHaveLength(0);
+    // Mapping teardown ran too: no row still points at the tenant.
+    expect(world.db.users.every((u) => u.tenant === null)).toBe(true);
+  });
+});

--- a/src/services/tenant/tenant-provisioning.chaos.spec.ts
+++ b/src/services/tenant/tenant-provisioning.chaos.spec.ts
@@ -1,0 +1,385 @@
+import { Logger } from '@nestjs/common';
+import axios from 'axios';
+import {
+  buildChaosWorld,
+  SeedUser,
+  AxiosMockLike,
+  installChaosTimers,
+  uninstallChaosTimers,
+  drain,
+  drainUntil,
+} from '../../mock/chaos';
+import { BulkConnectResult } from './tenant-provisioning.service';
+import { OutlookEventTypes } from '../../enums/event-types.enum';
+
+jest.mock('axios');
+const mockedAxios = axios as jest.Mocked<typeof axios> as unknown as AxiosMockLike;
+
+jest.setTimeout(120_000);
+
+/**
+ * Chaos + scale tests for TenantProvisioningService.connectUsers — the REAL service stack
+ * (provisioning → tenant-user → subscription) against an in-memory Graph/DB that injects
+ * latency, throttling, server errors, and planned failures.
+ */
+describe('TenantProvisioningService — chaos at scale', () => {
+  const SEED = Number(process.env.CHAOS_SEED ?? 20260714);
+  const TENANT = 'tenant-t1-guid';
+
+  const freshUsers = (n: number, prefix = 'fresh'): SeedUser[] =>
+    Array.from({ length: n }, (_, i) => ({
+      externalUserId: `${prefix}-${i}`,
+      email: `${prefix}-${i}@contoso.com`,
+      kind: 'bare' as const,
+      inDb: false, // no microsoft_users row yet — the connect flow creates it
+    }));
+
+  const inputsOf = (seeds: SeedUser[]) =>
+    seeds.map((s) => ({ externalUserId: s.externalUserId, email: s.email }));
+
+  beforeAll(() => {
+    Logger.overrideLogger(false);
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    installChaosTimers();
+  });
+
+  afterEach(() => {
+    uninstallChaosTimers();
+  });
+
+  it('baseline (no chaos): connects 520 users with exact Graph/DB consumption (incl. >500 IN-chunking)', async () => {
+    const seeds = freshUsers(520);
+    const world = buildChaosWorld(mockedAxios, { seed: SEED, users: seeds });
+
+    const result = await drain(world.services.provisioningService.connectUsers(TENANT, inputsOf(seeds)));
+
+    expect(result).toMatchObject({ total: 520, connected: 520, skipped: 0, failed: 0 });
+
+    // Graph consumption: exactly one lookup + one create per user, no dedupe deletes.
+    expect(world.metrics.attemptsFor('users.lookup')).toBe(520);
+    expect(world.metrics.attemptsFor('subs.create')).toBe(520);
+    expect(world.metrics.attemptsFor('subs.delete')).toBe(0);
+    // Bounded concurrency at the Graph boundary.
+    expect(world.metrics.peakInFlight).toBeLessThanOrEqual(5);
+    expect(world.metrics.peakInFlight).toBeGreaterThan(1);
+    // The already-connected pre-filter is bulk queries, not N: 520 external ids exceed the
+    // 500-per-IN chunk limit, so the user lookup runs exactly TWO chunked queries.
+    expect(world.metrics.dbCallsFor('users.find')).toBe(2);
+    expect(world.metrics.dbCallsFor('subs.findAllActiveByTenantId')).toBe(1);
+
+    // End-state: every user holds exactly one active subscription, both locally and at Graph.
+    for (const seed of seeds) {
+      const subs = world.helpers.activeDbSubsOf(seed.externalUserId);
+      expect(subs).toHaveLength(1);
+      expect(world.graph.subscriptions.has(subs[0].subscriptionId)).toBe(true);
+    }
+    expect(world.graph.subscriptionIdsForResourcePrefix('/users/')).toHaveLength(520);
+
+    const completed = world.helpers.eventsNamed(OutlookEventTypes.TENANT_USERS_BULK_CONNECT_COMPLETED);
+    expect(completed).toHaveLength(1);
+    expect(completed[0].payload as BulkConnectResult).toMatchObject({ connected: 520, failed: 0 });
+
+    console.log(world.metrics.report(`bulk-connect baseline N=520 seed=${SEED}`));
+  });
+
+  it('chaos storm: 300 users under 429/503/500/network + latency — conserves tallies, no duplicates', async () => {
+    const seeds = freshUsers(300, 'storm');
+    const world = buildChaosWorld(mockedAxios, {
+      seed: SEED,
+      users: seeds,
+      graphRates: { throttle429: 0.15, unavailable503: 0.05, serverError500: 0.05, networkError: 0.05 },
+      graphLatencyMs: { min: 1, max: 20 },
+    });
+
+    const result = await drain(world.services.provisioningService.connectUsers(TENANT, inputsOf(seeds)));
+
+    // Conservation: every requested user is accounted for exactly once.
+    expect(result.total).toBe(300);
+    expect(result.connected + result.failed).toBe(300);
+    expect(result.skipped).toBe(0);
+    expect(result.results).toHaveLength(300);
+    // The storm actually happened; retry depth stays within the configured ceilings
+    // (lookup maxRetries=3 ⇒ ≤4 attempts/user; create maxRetries=7 ⇒ ≤8 attempts/user).
+    expect(world.metrics.totalInjected()).toBeGreaterThan(0);
+    expect(world.metrics.attemptsFor('subs.create')).toBeGreaterThanOrEqual(result.connected);
+    expect(world.metrics.attemptsFor('users.lookup')).toBeLessThanOrEqual(4 * 300);
+    expect(world.metrics.attemptsFor('subs.create')).toBeLessThanOrEqual(8 * 300);
+    // Concurrency ceiling holds under disruption.
+    expect(world.metrics.peakInFlight).toBeLessThanOrEqual(5);
+
+    // No duplicates and no orphans for FAIL-BEFORE-MUTATE disruption (this storm's mode):
+    // connected ⇒ exactly one sub; failed ⇒ zero subs. The at-least-once case (response lost
+    // AFTER Graph applied the create) is exercised separately below.
+    for (const r of result.results) {
+      const subs = world.helpers.activeDbSubsOf(r.externalUserId);
+      if (r.success) {
+        expect(subs).toHaveLength(1);
+        expect(world.graph.subscriptions.has(subs[0].subscriptionId)).toBe(true);
+      } else {
+        expect(subs).toHaveLength(0);
+        expect(r.error).toBeTruthy();
+      }
+    }
+    expect(world.graph.subscriptionIdsForResourcePrefix('/users/')).toHaveLength(result.connected);
+
+    // The completion event fires exactly once, with the same tallies the caller received.
+    const completed = world.helpers.eventsNamed(OutlookEventTypes.TENANT_USERS_BULK_CONNECT_COMPLETED);
+    expect(completed).toHaveLength(1);
+    expect(completed[0].payload as BulkConnectResult).toMatchObject({
+      connected: result.connected,
+      failed: result.failed,
+    });
+
+    console.log(world.metrics.report(`bulk-connect storm N=300 seed=${SEED}`));
+  });
+
+  it('at-least-once reality: a create whose RESPONSE is lost after Graph applied it duplicates at Graph on retry', async () => {
+    const seeds = freshUsers(40, 'lostack');
+    const world = buildChaosWorld(mockedAxios, { seed: SEED, users: seeds });
+
+    // For 10 users the first create attempt MUTATES Graph, then the response is lost
+    // (network drop). Production retries the non-idempotent POST — the retry succeeds,
+    // leaving TWO live Graph subscriptions while the local DB knows only the second.
+    const lostAck = seeds.slice(0, 10);
+    for (const s of lostAck) {
+      world.engine.failTimesAfterExecute('subs.create', world.helpers.msIdOf(s.externalUserId), 1, 'network');
+    }
+
+    const result = await drain(world.services.provisioningService.connectUsers(TENANT, inputsOf(seeds)));
+
+    expect(result).toMatchObject({ connected: 40, failed: 0 });
+    for (const s of lostAck) {
+      expect(world.helpers.activeDbSubsOf(s.externalUserId)).toHaveLength(1); // DB is clean…
+    }
+    // …but Graph holds an untracked duplicate per lost-ack user. This DOCUMENTS the current
+    // production behaviour (known wart): both subs carry the SAME clientState, so the webhook
+    // guard accepts notifications from the orphan too — duplicate notifications until it
+    // expires (≤3 days). Remediation (create-time reconciliation) is a follow-up.
+    expect(world.graph.subscriptionIdsForResourcePrefix('/users/')).toHaveLength(40 + 10);
+  });
+
+  it('orphan window: Graph create succeeds but the subscription SAVE fails — user fails cleanly, orphan documented', async () => {
+    const seeds = freshUsers(30, 'orphan');
+    const world = buildChaosWorld(mockedAxios, { seed: SEED, users: seeds });
+
+    const dbFails = seeds.slice(0, 6);
+    for (const s of dbFails) world.engine.alwaysFail('db.subs.save', s.externalUserId, 500);
+
+    const result = await drain(world.services.provisioningService.connectUsers(TENANT, inputsOf(seeds)));
+
+    expect(result.failed).toBe(6);
+    expect(result.connected).toBe(24);
+    for (const s of dbFails) {
+      // The user is reported failed with no local subscription…
+      expect(world.helpers.activeDbSubsOf(s.externalUserId)).toHaveLength(0);
+    }
+    // …but the Graph-side subscription was already created: an orphan per failed save.
+    // Mitigation in production: its clientState was never persisted, so the webhook
+    // clientState guard rejects the orphan's notifications, and it expires within 3 days.
+    expect(world.graph.subscriptionIdsForResourcePrefix('/users/')).toHaveLength(24 + 6);
+  });
+
+  it('duplicate externalUserIds in one request are de-duplicated (no concurrent double-subscribe race)', async () => {
+    const seeds = freshUsers(30, 'dup');
+    const world = buildChaosWorld(mockedAxios, {
+      seed: SEED,
+      users: seeds,
+      graphLatencyMs: { min: 5, max: 25 }, // overlap window for would-be concurrent duplicates
+    });
+
+    // Every user appears TWICE in the request.
+    const doubled = [...inputsOf(seeds), ...inputsOf(seeds)];
+    const result = await drain(world.services.provisioningService.connectUsers(TENANT, doubled));
+
+    expect(result.total).toBe(30);
+    expect(result.connected).toBe(30);
+    expect(result.results).toHaveLength(30);
+    // Exactly one create per user — the duplicate never raced the dedupe guard.
+    expect(world.metrics.attemptsFor('subs.create')).toBe(30);
+    for (const s of seeds) {
+      expect(world.helpers.activeDbSubsOf(s.externalUserId)).toHaveLength(1);
+    }
+    expect(world.graph.subscriptionIdsForResourcePrefix('/users/')).toHaveLength(30);
+  });
+
+  it('planned failures are exact: 403 lookups fail fast (1 attempt), sticky 500 creates exhaust retries (8 attempts)', async () => {
+    const seeds = freshUsers(200, 'plan');
+    const world = buildChaosWorld(mockedAxios, { seed: SEED, users: seeds });
+
+    const lookupFails = seeds.slice(0, 12);
+    const createFails = seeds.slice(12, 22);
+    for (const s of lookupFails) world.engine.alwaysFail('users.lookup', s.email, 403);
+    for (const s of createFails) world.engine.alwaysFail('subs.create', world.helpers.msIdOf(s.externalUserId), 500);
+
+    const result = await drain(world.services.provisioningService.connectUsers(TENANT, inputsOf(seeds)));
+
+    expect(result.failed).toBe(22);
+    expect(result.connected).toBe(178);
+
+    // 403 is non-retryable: exactly one attempt, immediate failure.
+    for (const s of lookupFails) {
+      expect(world.metrics.attemptsForKey('users.lookup', s.email)).toBe(1);
+    }
+    // 500 is retryable: maxRetries=7 ⇒ exactly 8 attempts before giving up.
+    for (const s of createFails) {
+      expect(world.metrics.attemptsForKey('subs.create', world.helpers.msIdOf(s.externalUserId))).toBe(8);
+    }
+    // Failed creates never mutated Graph.
+    expect(world.graph.subscriptionIdsForResourcePrefix('/users/')).toHaveLength(178);
+  });
+
+  it('transient 429s recover: fail-twice keys succeed on the 3rd attempt', async () => {
+    const seeds = freshUsers(100, 'transient');
+    const world = buildChaosWorld(mockedAxios, { seed: SEED, users: seeds });
+
+    const flaky = seeds.slice(0, 20);
+    for (const s of flaky) world.engine.failTimes('subs.create', world.helpers.msIdOf(s.externalUserId), 2, 429);
+
+    const result = await drain(world.services.provisioningService.connectUsers(TENANT, inputsOf(seeds)));
+
+    expect(result).toMatchObject({ connected: 100, failed: 0 });
+    for (const s of flaky) {
+      expect(world.metrics.attemptsForKey('subs.create', world.helpers.msIdOf(s.externalUserId))).toBe(3);
+    }
+    expect(world.metrics.injectedFor('subs.create', 429)).toBe(40);
+  });
+
+  it('existing delegated users: old /me/events subscription removed before app-only create — dedupe guard under disruption', async () => {
+    const delegated: SeedUser[] = Array.from({ length: 40 }, (_, i) => ({
+      externalUserId: `deleg-${i}`,
+      email: `deleg-${i}@contoso.com`,
+      kind: 'delegated',
+      sub: { mode: 'delegated' },
+    }));
+    const fresh = freshUsers(110, 'new');
+    const all = [...delegated, ...fresh];
+    const world = buildChaosWorld(mockedAxios, { seed: SEED, users: all });
+
+    expect(world.graph.subscriptionIdsForResourcePrefix('/me/events')).toHaveLength(40);
+
+    // Disrupt the guard's deletes: 5 are throttled twice (must retry through), 3 hard-fail
+    // (best-effort — the guard must proceed to create anyway).
+    const subIdOf = (ext: string): string => world.helpers.activeDbSubsOf(ext)[0].subscriptionId;
+    const flaky = delegated.slice(0, 5).map((s) => subIdOf(s.externalUserId));
+    const sticky = delegated.slice(5, 8).map((s) => subIdOf(s.externalUserId));
+    for (const id of flaky) world.engine.failTimes('subs.delete', id, 2, 429);
+    for (const id of sticky) world.engine.alwaysFail('subs.delete', id, 500);
+
+    const result = await drain(world.services.provisioningService.connectUsers(TENANT, inputsOf(all)));
+
+    // Best-effort guard: even the 3 failed deletes never blocked the connect.
+    expect(result).toMatchObject({ connected: 150, skipped: 0, failed: 0 });
+    // Delete attempts: 32 clean (1 each) + 5 flaky (3 each) + 3 sticky (retries exhausted, 8 each).
+    expect(world.metrics.attemptsFor('subs.delete')).toBe(32 + 5 * 3 + 3 * 8);
+    // The 3 sticky old subs remain at Graph (delete truly failed); everything else is gone.
+    expect(new Set(world.graph.subscriptionIdsForResourcePrefix('/me/events'))).toEqual(new Set(sticky));
+
+    for (const s of delegated) {
+      const subs = world.helpers.activeDbSubsOf(s.externalUserId);
+      expect(subs).toHaveLength(1); // old row deactivated locally in ALL cases
+      expect(subs[0].resource.startsWith('/users/')).toBe(true); // converged to app-only
+    }
+  });
+
+  it('idempotency: already-connected users are skipped without any Graph traffic; a rerun converges', async () => {
+    const connected: SeedUser[] = Array.from({ length: 60 }, (_, i) => ({
+      externalUserId: `done-${i}`,
+      email: `done-${i}@contoso.com`,
+      kind: 'app-only',
+      sub: { mode: 'app-only' },
+    }));
+    const fresh = freshUsers(90, 'todo');
+    const all = [...connected, ...fresh];
+    const world = buildChaosWorld(mockedAxios, {
+      seed: SEED,
+      users: all,
+      graphRates: { throttle429: 0.1 },
+      graphLatencyMs: { min: 1, max: 5 },
+    });
+
+    const run1 = await drain(world.services.provisioningService.connectUsers(TENANT, inputsOf(all)));
+
+    expect(run1.skipped).toBe(60); // deterministic even under chaos — decided from DB pre-filter
+    expect(run1.connected + run1.failed).toBe(90);
+    // Skipped users generated ZERO Graph traffic.
+    for (const s of connected) {
+      expect(world.metrics.attemptsForKey('users.lookup', s.email)).toBe(0);
+      expect(world.metrics.attemptsForKey('subs.create', world.helpers.msIdOf(s.externalUserId))).toBe(0);
+    }
+
+    // Rerun with calm weather: everything converges to connected, nothing is torn down.
+    world.engine.setRates({});
+    const run2 = await drain(world.services.provisioningService.connectUsers(TENANT, inputsOf(all)));
+    expect(run2.skipped).toBe(60 + run1.connected);
+    expect(run2.failed).toBe(0);
+    expect(run2.connected).toBe(run1.failed);
+    for (const s of all) {
+      expect(world.helpers.activeDbSubsOf(s.externalUserId).length).toBeLessThanOrEqual(1);
+    }
+    // "Nothing is torn down" — no dedupe delete ever fired (skipped users are pre-filtered,
+    // fresh users have nothing to remove), and the 60 seeded users still hold their ORIGINAL
+    // subscriptions untouched.
+    expect(world.metrics.attemptsFor('subs.delete')).toBe(0);
+    for (const s of connected) {
+      const subs = world.helpers.activeDbSubsOf(s.externalUserId);
+      expect(subs).toHaveLength(1);
+      expect(subs[0].subscriptionId.startsWith('seed-sub-')).toBe(true);
+    }
+  });
+
+  it('database chaos: latency plus planned save failures — failures recorded, batch completes', async () => {
+    const seeds = freshUsers(150, 'dbchaos');
+    const world = buildChaosWorld(mockedAxios, {
+      seed: SEED,
+      users: seeds,
+      dbLatencyMs: { min: 1, max: 5 },
+    });
+
+    const dbFails = seeds.slice(0, 8);
+    for (const s of dbFails) world.engine.alwaysFail('db.users.save', s.externalUserId, 500);
+
+    const result = await drain(world.services.provisioningService.connectUsers(TENANT, inputsOf(seeds)));
+
+    expect(result.failed).toBe(8);
+    expect(result.connected).toBe(142);
+    for (const s of dbFails) {
+      const r = result.results.find((x) => x.externalUserId === s.externalUserId);
+      expect(r?.success).toBe(false);
+      expect(r?.error).toContain('chaos db failure');
+      // The mapping save fails BEFORE any Graph create — no external side effects for them.
+      expect(world.metrics.attemptsForKey('subs.create', world.helpers.msIdOf(s.externalUserId))).toBe(0);
+      expect(world.helpers.activeDbSubsOf(s.externalUserId)).toHaveLength(0);
+    }
+    expect(world.graph.subscriptionIdsForResourcePrefix('/users/')).toHaveLength(142);
+  });
+
+  it('host contract: POST users/connect returns before the background flow completes', async () => {
+    const seeds = freshUsers(80, 'http');
+    const world = buildChaosWorld(mockedAxios, {
+      seed: SEED,
+      users: seeds,
+      graphLatencyMs: { min: 5, max: 30 },
+    });
+
+    const response = world.controllers.tenantAuthController.connectUsers({
+      tenantId: TENANT,
+      users: inputsOf(seeds),
+    });
+
+    // The endpoint answered synchronously; the chaotic background work has not finished.
+    expect(response.totalRequested).toBe(80);
+    expect(response.message).toContain('background');
+    expect(world.helpers.eventsNamed(OutlookEventTypes.TENANT_USERS_BULK_CONNECT_COMPLETED)).toHaveLength(0);
+
+    await drainUntil(
+      () => world.helpers.eventsNamed(OutlookEventTypes.TENANT_USERS_BULK_CONNECT_COMPLETED).length === 1,
+    );
+    const summary = world.helpers.eventsNamed(OutlookEventTypes.TENANT_USERS_BULK_CONNECT_COMPLETED)[0]
+      .payload as BulkConnectResult;
+    // Latency-only chaos ⇒ deterministic outcome: every user actually connected.
+    expect(summary).toMatchObject({ total: 80, connected: 80, failed: 0, skipped: 0 });
+  });
+});

--- a/src/services/tenant/tenant-provisioning.service.spec.ts
+++ b/src/services/tenant/tenant-provisioning.service.spec.ts
@@ -5,12 +5,15 @@ import { MicrosoftSubscriptionService } from '../subscription/microsoft-subscrip
 import { MicrosoftTenantRepository } from '../../repositories/microsoft-tenant.repository';
 import { MicrosoftTenant } from '../../entities/microsoft-tenant.entity';
 import { MicrosoftUser } from '../../entities/microsoft-user.entity';
+import { OutlookWebhookSubscription } from '../../entities/outlook-webhook-subscription.entity';
 import { OutlookEventTypes } from '../../enums/event-types.enum';
 
 describe('TenantProvisioningService', () => {
   let service: TenantProvisioningService;
-  let tenantUserService: jest.Mocked<Pick<TenantUserService, 'registerUserMapping'>>;
-  let subscriptionService: jest.Mocked<Pick<MicrosoftSubscriptionService, 'createAppOnlyWebhookSubscription'>>;
+  let tenantUserService: jest.Mocked<Pick<TenantUserService, 'registerUserMapping' | 'findUsersByExternalIds'>>;
+  let subscriptionService: jest.Mocked<
+    Pick<MicrosoftSubscriptionService, 'createAppOnlyWebhookSubscription' | 'getAppOnlySubscriptionsForTenant'>
+  >;
   let tenantRepository: jest.Mocked<Pick<MicrosoftTenantRepository, 'findByTenantId'>>;
   let eventEmitter: jest.Mocked<Pick<EventEmitter2, 'emit'>>;
 
@@ -21,8 +24,16 @@ describe('TenantProvisioningService', () => {
     ({ externalUserId, microsoftUserId: `ms-${externalUserId}` }) as MicrosoftUser;
 
   beforeEach(() => {
-    tenantUserService = { registerUserMapping: jest.fn() };
-    subscriptionService = { createAppOnlyWebhookSubscription: jest.fn() };
+    tenantUserService = {
+      registerUserMapping: jest.fn(),
+      // Default: no user is already persisted, so nothing is skipped.
+      findUsersByExternalIds: jest.fn().mockResolvedValue([]),
+    };
+    subscriptionService = {
+      createAppOnlyWebhookSubscription: jest.fn(),
+      // Default: tenant has no active subscriptions, so nothing is skipped.
+      getAppOnlySubscriptionsForTenant: jest.fn().mockResolvedValue([]),
+    };
     tenantRepository = { findByTenantId: jest.fn().mockResolvedValue({ tenantId } as MicrosoftTenant) };
     eventEmitter = { emit: jest.fn() };
 
@@ -69,6 +80,38 @@ describe('TenantProvisioningService', () => {
       OutlookEventTypes.TENANT_USERS_BULK_CONNECT_COMPLETED,
       expect.objectContaining({ tenantId, connected: 3, failed: 0 }),
     );
+  });
+
+  it('skips users already connected to the tenant (does not re-create their subscription)', async () => {
+    const users: BulkConnectUserInput[] = [
+      { externalUserId: 'already', email: 'already@contoso.com' },
+      { externalUserId: 'fresh', email: 'fresh@contoso.com' },
+    ];
+    // 'already' has internal id 10 and an active app-only subscription for this tenant.
+    subscriptionService.getAppOnlySubscriptionsForTenant.mockResolvedValueOnce([
+      { userId: 10 } as OutlookWebhookSubscription,
+    ]);
+    tenantUserService.findUsersByExternalIds.mockResolvedValueOnce([
+      { externalUserId: 'already', id: 10, microsoftUserId: 'ms-already' } as MicrosoftUser,
+    ]);
+    tenantUserService.registerUserMapping.mockResolvedValue(mappedUser('fresh'));
+    subscriptionService.createAppOnlyWebhookSubscription.mockResolvedValue({ id: 'sub-fresh' });
+
+    const result = await service.connectUsers(tenantId, users);
+
+    expect(result.total).toBe(2);
+    expect(result.skipped).toBe(1);
+    expect(result.connected).toBe(1);
+    expect(result.failed).toBe(0);
+    // The already-connected user is never re-mapped or re-subscribed — no override.
+    expect(tenantUserService.registerUserMapping).toHaveBeenCalledTimes(1);
+    expect(tenantUserService.registerUserMapping).toHaveBeenCalledWith(tenantId, 'fresh', 'fresh@contoso.com');
+    expect(subscriptionService.createAppOnlyWebhookSubscription).toHaveBeenCalledTimes(1);
+    // The skipped user is reported as such.
+    expect(result.results.find((r) => r.externalUserId === 'already')).toMatchObject({
+      success: true,
+      skipped: true,
+    });
   });
 
   it('records a per-user failure without aborting the batch', async () => {

--- a/src/services/tenant/tenant-provisioning.service.spec.ts
+++ b/src/services/tenant/tenant-provisioning.service.spec.ts
@@ -1,0 +1,145 @@
+import { EventEmitter2 } from '@nestjs/event-emitter';
+import { TenantProvisioningService, BulkConnectUserInput } from './tenant-provisioning.service';
+import { TenantUserService } from './tenant-user.service';
+import { MicrosoftSubscriptionService } from '../subscription/microsoft-subscription.service';
+import { MicrosoftTenantRepository } from '../../repositories/microsoft-tenant.repository';
+import { MicrosoftTenant } from '../../entities/microsoft-tenant.entity';
+import { MicrosoftUser } from '../../entities/microsoft-user.entity';
+import { OutlookEventTypes } from '../../enums/event-types.enum';
+
+describe('TenantProvisioningService', () => {
+  let service: TenantProvisioningService;
+  let tenantUserService: jest.Mocked<Pick<TenantUserService, 'registerUserMapping'>>;
+  let subscriptionService: jest.Mocked<Pick<MicrosoftSubscriptionService, 'createAppOnlyWebhookSubscription'>>;
+  let tenantRepository: jest.Mocked<Pick<MicrosoftTenantRepository, 'findByTenantId'>>;
+  let eventEmitter: jest.Mocked<Pick<EventEmitter2, 'emit'>>;
+
+  const tenantId = '12345678-1234-1234-1234-123456789abc';
+
+  // registerUserMapping returns the mapped MicrosoftUser with a resolved microsoftUserId.
+  const mappedUser = (externalUserId: string): MicrosoftUser =>
+    ({ externalUserId, microsoftUserId: `ms-${externalUserId}` }) as MicrosoftUser;
+
+  beforeEach(() => {
+    tenantUserService = { registerUserMapping: jest.fn() };
+    subscriptionService = { createAppOnlyWebhookSubscription: jest.fn() };
+    tenantRepository = { findByTenantId: jest.fn().mockResolvedValue({ tenantId } as MicrosoftTenant) };
+    eventEmitter = { emit: jest.fn() };
+
+    service = new TenantProvisioningService(
+      tenantUserService as unknown as TenantUserService,
+      subscriptionService as unknown as MicrosoftSubscriptionService,
+      tenantRepository as unknown as MicrosoftTenantRepository,
+      eventEmitter as unknown as EventEmitter2,
+    );
+  });
+
+  it('connects every user: maps + creates a subscription, and emits a completion event', async () => {
+    const users: BulkConnectUserInput[] = [
+      { externalUserId: 'insp-1', email: 'a@contoso.com' },
+      { externalUserId: 'insp-2', email: 'b@contoso.com' },
+      { externalUserId: 'insp-3', email: 'c@contoso.com' },
+    ];
+    tenantUserService.registerUserMapping.mockImplementation(async (_t, ext) => mappedUser(ext));
+    subscriptionService.createAppOnlyWebhookSubscription.mockImplementation(async (opts) => ({
+      id: `sub-${opts.externalUserId}`,
+    }));
+
+    const result = await service.connectUsers(tenantId, users);
+
+    expect(result.total).toBe(3);
+    expect(result.connected).toBe(3);
+    expect(result.failed).toBe(0);
+    // Each user was mapped then subscribed, with the resolved microsoftUserId.
+    expect(tenantUserService.registerUserMapping).toHaveBeenCalledTimes(3);
+    expect(tenantUserService.registerUserMapping).toHaveBeenCalledWith(tenantId, 'insp-1', 'a@contoso.com');
+    expect(subscriptionService.createAppOnlyWebhookSubscription).toHaveBeenCalledWith({
+      tenantId,
+      microsoftUserId: 'ms-insp-1',
+      externalUserId: 'insp-1',
+    });
+    // Results carry the created subscription id.
+    expect(result.results.find((r) => r.externalUserId === 'insp-2')).toMatchObject({
+      success: true,
+      microsoftUserId: 'ms-insp-2',
+      subscriptionId: 'sub-insp-2',
+    });
+    // Completion event emitted with the summary.
+    expect(eventEmitter.emit).toHaveBeenCalledWith(
+      OutlookEventTypes.TENANT_USERS_BULK_CONNECT_COMPLETED,
+      expect.objectContaining({ tenantId, connected: 3, failed: 0 }),
+    );
+  });
+
+  it('records a per-user failure without aborting the batch', async () => {
+    const users: BulkConnectUserInput[] = [
+      { externalUserId: 'ok-1', email: 'ok@contoso.com' },
+      { externalUserId: 'missing', email: 'nope@contoso.com' },
+    ];
+    tenantUserService.registerUserMapping.mockImplementation(async (_t, ext, email) => {
+      if (ext === 'missing') {
+        throw new Error(`User not found in tenant: ${email}`);
+      }
+      return mappedUser(ext);
+    });
+    subscriptionService.createAppOnlyWebhookSubscription.mockResolvedValue({ id: 'sub-ok-1' });
+
+    const result = await service.connectUsers(tenantId, users);
+
+    expect(result.connected).toBe(1);
+    expect(result.failed).toBe(1);
+    const failed = result.results.find((r) => r.externalUserId === 'missing');
+    expect(failed).toMatchObject({ success: false });
+    expect(failed?.error).toContain('User not found in tenant');
+    // The failing user never reached subscription creation; the other one did.
+    expect(subscriptionService.createAppOnlyWebhookSubscription).toHaveBeenCalledTimes(1);
+    // Completion event still emitted.
+    expect(eventEmitter.emit).toHaveBeenCalledWith(
+      OutlookEventTypes.TENANT_USERS_BULK_CONNECT_COMPLETED,
+      expect.objectContaining({ connected: 1, failed: 1 }),
+    );
+  });
+
+  it('fails fast and emits FAILED when the tenant is not found', async () => {
+    tenantRepository.findByTenantId.mockResolvedValueOnce(null);
+
+    await expect(
+      service.connectUsers(tenantId, [{ externalUserId: 'x', email: 'x@contoso.com' }]),
+    ).rejects.toThrow('Tenant not found');
+
+    // No per-user work happened.
+    expect(tenantUserService.registerUserMapping).not.toHaveBeenCalled();
+    expect(subscriptionService.createAppOnlyWebhookSubscription).not.toHaveBeenCalled();
+    expect(eventEmitter.emit).toHaveBeenCalledWith(
+      OutlookEventTypes.TENANT_USERS_BULK_CONNECT_FAILED,
+      expect.objectContaining({ tenantId }),
+    );
+  });
+
+  it('marks a user failed when the mapping resolves no Microsoft user id', async () => {
+    tenantUserService.registerUserMapping.mockResolvedValueOnce(
+      { externalUserId: 'no-ms', microsoftUserId: null } as MicrosoftUser,
+    );
+
+    const result = await service.connectUsers(tenantId, [{ externalUserId: 'no-ms', email: 'x@contoso.com' }]);
+
+    expect(result.failed).toBe(1);
+    expect(subscriptionService.createAppOnlyWebhookSubscription).not.toHaveBeenCalled();
+  });
+
+  it('processes every user in a larger batch (bounded concurrency)', async () => {
+    const users: BulkConnectUserInput[] = Array.from({ length: 23 }, (_, i) => ({
+      externalUserId: `u-${i}`,
+      email: `u${i}@contoso.com`,
+    }));
+    tenantUserService.registerUserMapping.mockImplementation(async (_t, ext) => mappedUser(ext));
+    subscriptionService.createAppOnlyWebhookSubscription.mockResolvedValue({ id: 'sub' });
+
+    const result = await service.connectUsers(tenantId, users);
+
+    expect(result.total).toBe(23);
+    expect(result.connected).toBe(23);
+    expect(tenantUserService.registerUserMapping).toHaveBeenCalledTimes(23);
+    expect(subscriptionService.createAppOnlyWebhookSubscription).toHaveBeenCalledTimes(23);
+  });
+});

--- a/src/services/tenant/tenant-provisioning.service.ts
+++ b/src/services/tenant/tenant-provisioning.service.ts
@@ -1,0 +1,171 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { EventEmitter2 } from '@nestjs/event-emitter';
+import { TenantUserService } from './tenant-user.service';
+import { MicrosoftSubscriptionService } from '../subscription/microsoft-subscription.service';
+import { MicrosoftTenantRepository } from '../../repositories/microsoft-tenant.repository';
+import { mapWithConcurrency } from '../../utils/concurrent-map.util';
+import { OutlookEventTypes } from '../../enums/event-types.enum';
+
+/**
+ * One user to connect into a tenant. `email` is required because the module resolves the
+ * Microsoft account by email/UPN (Graph `/users?$filter=mail eq …`) — an external id alone
+ * cannot be mapped to a Microsoft user.
+ */
+export interface BulkConnectUserInput {
+  externalUserId: string;
+  /** Email or user principal name (UPN) that exists in the tenant. */
+  email: string;
+}
+
+/** Per-user outcome of a bulk connect. */
+export interface BulkConnectUserResult {
+  externalUserId: string;
+  success: boolean;
+  microsoftUserId?: string;
+  subscriptionId?: string;
+  error?: string;
+}
+
+/** Summary of a bulk connect run. */
+export interface BulkConnectResult {
+  tenantId: string;
+  total: number;
+  connected: number;
+  failed: number;
+  results: BulkConnectUserResult[];
+}
+
+/**
+ * Orchestrates connecting many users into a tenant (app-only) in one call.
+ *
+ * For each user it upserts the `microsoft_users` mapping and creates an app-only Outlook
+ * calendar webhook subscription. Users who already have a delegated subscription are handled
+ * transparently: `createAppOnlyWebhookSubscription` removes any existing calendar subscription
+ * (at Microsoft and locally) before creating the new one, so a mailbox never ends up with two
+ * live subscriptions.
+ *
+ * Designed for scale: work runs at bounded concurrency (Graph subscription creation cannot be
+ * batched — Graph validates each notificationUrl at creation — so concurrency, not $batch, is
+ * the lever). A per-user failure is recorded and never aborts the run.
+ */
+@Injectable()
+export class TenantProvisioningService {
+  private readonly logger = new Logger(TenantProvisioningService.name);
+
+  /**
+   * Max concurrent per-user connect flows. Kept small so we don't burst Graph (each user is a
+   * lookup + optional delete + create) and so simultaneous subscription-validation callbacks
+   * stay manageable. Matches the revocation concurrency used elsewhere.
+   */
+  private readonly CONNECT_CONCURRENCY = 5;
+
+  constructor(
+    private readonly tenantUserService: TenantUserService,
+    private readonly subscriptionService: MicrosoftSubscriptionService,
+    private readonly tenantRepository: MicrosoftTenantRepository,
+    private readonly eventEmitter: EventEmitter2,
+  ) {}
+
+  /**
+   * Connect a batch of users into a tenant: upsert each mapping and create an app-only
+   * calendar subscription. Emits {@link OutlookEventTypes.TENANT_USERS_BULK_CONNECT_COMPLETED}
+   * with the summary on completion (or `..._FAILED` if the run can't start), so callers that
+   * kicked this off in the background can observe the outcome.
+   *
+   * @param tenantId - Azure AD tenant GUID the users belong to (must be connected/active).
+   * @param users - Users to connect (`{ externalUserId, email }`).
+   * @returns Per-user results plus connected/failed tallies.
+   */
+  async connectUsers(
+    tenantId: string,
+    users: BulkConnectUserInput[],
+  ): Promise<BulkConnectResult> {
+    const correlationId = `bulk-connect-${tenantId}-${Date.now()}`;
+    this.logger.log(
+      `[${correlationId}] Bulk connect requested for ${users.length} user(s) into tenant ${tenantId}`,
+    );
+
+    // Pre-flight: resolve the tenant once. If it isn't there, fail the whole run fast with a
+    // clear reason instead of failing every user with the same "tenant not found" error.
+    const tenant = await this.tenantRepository.findByTenantId(tenantId);
+    if (!tenant) {
+      const message = `Tenant not found or not connected: ${tenantId}`;
+      this.logger.error(`[${correlationId}] ${message}`);
+      this.eventEmitter.emit(OutlookEventTypes.TENANT_USERS_BULK_CONNECT_FAILED, {
+        tenantId,
+        total: users.length,
+        error: message,
+      });
+      throw new Error(message);
+    }
+
+    const results = await mapWithConcurrency(
+      users,
+      this.CONNECT_CONCURRENCY,
+      (user) => this.connectOneUser(tenantId, user, correlationId),
+    );
+
+    const connected = results.filter((r) => r.success).length;
+    const summary: BulkConnectResult = {
+      tenantId,
+      total: users.length,
+      connected,
+      failed: results.length - connected,
+      results,
+    };
+
+    this.logger.log(
+      `[${correlationId}] Bulk connect complete for tenant ${tenantId}: ` +
+      `${summary.connected} connected, ${summary.failed} failed`,
+    );
+    this.eventEmitter.emit(OutlookEventTypes.TENANT_USERS_BULK_CONNECT_COMPLETED, summary);
+
+    return summary;
+  }
+
+  /**
+   * Connect a single user: upsert the mapping, then create the app-only subscription
+   * (which first removes any existing calendar subscription for the user). Never throws —
+   * a failure is captured in the returned result so the batch continues.
+   */
+  private async connectOneUser(
+    tenantId: string,
+    user: BulkConnectUserInput,
+    correlationId: string,
+  ): Promise<BulkConnectUserResult> {
+    try {
+      const mapped = await this.tenantUserService.registerUserMapping(
+        tenantId,
+        user.externalUserId,
+        user.email,
+      );
+
+      if (!mapped.microsoftUserId) {
+        throw new Error('User mapping did not resolve a Microsoft user id');
+      }
+
+      const subscription = await this.subscriptionService.createAppOnlyWebhookSubscription({
+        tenantId,
+        microsoftUserId: mapped.microsoftUserId,
+        externalUserId: user.externalUserId,
+      });
+
+      return {
+        externalUserId: user.externalUserId,
+        success: true,
+        microsoftUserId: mapped.microsoftUserId,
+        subscriptionId: subscription.id ?? undefined,
+      };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unknown error';
+      this.logger.warn(
+        `[${correlationId}] Failed to connect user ${user.externalUserId}: ${message}`,
+      );
+      return {
+        externalUserId: user.externalUserId,
+        success: false,
+        error: message,
+      };
+    }
+  }
+}

--- a/src/services/tenant/tenant-provisioning.service.ts
+++ b/src/services/tenant/tenant-provisioning.service.ts
@@ -21,16 +21,21 @@ export interface BulkConnectUserInput {
 export interface BulkConnectUserResult {
   externalUserId: string;
   success: boolean;
+  /** True when the user was already connected to this tenant and left untouched. */
+  skipped?: boolean;
   microsoftUserId?: string;
   subscriptionId?: string;
   error?: string;
 }
 
-/** Summary of a bulk connect run. */
+/** Summary of a bulk connect run. `total = connected + skipped + failed`. */
 export interface BulkConnectResult {
   tenantId: string;
   total: number;
+  /** Newly connected (mapping upserted + subscription created). */
   connected: number;
+  /** Already connected to this tenant, so left as-is (not re-created). */
+  skipped: number;
   failed: number;
   results: BulkConnectUserResult[];
 }
@@ -68,7 +73,9 @@ export class TenantProvisioningService {
 
   /**
    * Connect a batch of users into a tenant: upsert each mapping and create an app-only
-   * calendar subscription. Emits {@link OutlookEventTypes.TENANT_USERS_BULK_CONNECT_COMPLETED}
+   * calendar subscription. Users already connected to this tenant (they have an active
+   * app-only subscription) are **skipped**, so a re-run never tears down a working
+   * connection. Emits {@link OutlookEventTypes.TENANT_USERS_BULK_CONNECT_COMPLETED}
    * with the summary on completion (or `..._FAILED` if the run can't start), so callers that
    * kicked this off in the background can observe the outcome.
    *
@@ -99,24 +106,59 @@ export class TenantProvisioningService {
       throw new Error(message);
     }
 
-    const results = await mapWithConcurrency(
-      users,
+    // Skip users already connected to this tenant so a re-run doesn't tear down and rebuild a
+    // working connection. "Connected" = has an active app-only subscription for this tenant.
+    // Two bulk queries (subscriptions by tenant + user rows by external id) — no per-user query.
+    const activeSubs = await this.subscriptionService.getAppOnlySubscriptionsForTenant(tenantId);
+    const connectedUserIds = new Set(activeSubs.map((sub) => sub.userId));
+    const existingRows = await this.tenantUserService.findUsersByExternalIds(
+      users.map((user) => user.externalUserId),
+    );
+    const rowByExternalId = new Map(existingRows.map((row) => [row.externalUserId, row]));
+
+    const toProcess: BulkConnectUserInput[] = [];
+    const skippedResults: BulkConnectUserResult[] = [];
+    for (const user of users) {
+      const row = rowByExternalId.get(user.externalUserId);
+      if (row && connectedUserIds.has(row.id)) {
+        skippedResults.push({
+          externalUserId: user.externalUserId,
+          success: true,
+          skipped: true,
+          microsoftUserId: row.microsoftUserId ?? undefined,
+        });
+      } else {
+        toProcess.push(user);
+      }
+    }
+
+    if (skippedResults.length > 0) {
+      this.logger.log(
+        `[${correlationId}] ${skippedResults.length} user(s) already connected — skipping; ` +
+        `processing ${toProcess.length}`,
+      );
+    }
+
+    const processed = await mapWithConcurrency(
+      toProcess,
       this.CONNECT_CONCURRENCY,
       (user) => this.connectOneUser(tenantId, user, correlationId),
     );
 
-    const connected = results.filter((r) => r.success).length;
+    const results = [...skippedResults, ...processed];
+    const connected = processed.filter((r) => r.success).length;
     const summary: BulkConnectResult = {
       tenantId,
       total: users.length,
       connected,
-      failed: results.length - connected,
+      skipped: skippedResults.length,
+      failed: processed.length - connected,
       results,
     };
 
     this.logger.log(
       `[${correlationId}] Bulk connect complete for tenant ${tenantId}: ` +
-      `${summary.connected} connected, ${summary.failed} failed`,
+      `${summary.connected} connected, ${summary.skipped} skipped, ${summary.failed} failed`,
     );
     this.eventEmitter.emit(OutlookEventTypes.TENANT_USERS_BULK_CONNECT_COMPLETED, summary);
 

--- a/src/services/tenant/tenant-provisioning.service.ts
+++ b/src/services/tenant/tenant-provisioning.service.ts
@@ -88,6 +88,17 @@ export class TenantProvisioningService {
     users: BulkConnectUserInput[],
   ): Promise<BulkConnectResult> {
     const correlationId = `bulk-connect-${tenantId}-${Date.now()}`;
+
+    // Dedupe the input by externalUserId (first occurrence wins). Two entries for the same
+    // user would run CONCURRENTLY through the per-user worker: both dedupe guards can observe
+    // "no existing subscription" before either create lands, double-subscribing the mailbox.
+    const seenIds = new Set<string>();
+    users = users.filter((user) => {
+      if (seenIds.has(user.externalUserId)) return false;
+      seenIds.add(user.externalUserId);
+      return true;
+    });
+
     this.logger.log(
       `[${correlationId}] Bulk connect requested for ${users.length} user(s) into tenant ${tenantId}`,
     );

--- a/src/services/tenant/tenant-user.service.spec.ts
+++ b/src/services/tenant/tenant-user.service.spec.ts
@@ -78,6 +78,7 @@ describe('TenantUserService', () => {
     const mockTenantUserRepository = {
       findOne: jest.fn(),
       save: jest.fn(),
+      createQueryBuilder: jest.fn(),
     };
 
     const module: TestingModule = await Test.createTestingModule({
@@ -616,6 +617,117 @@ describe('TenantUserService', () => {
       await expect(
         service.listUsers(mockTenantId)
       ).rejects.toThrow('Failed to list users');
+    });
+  });
+
+  describe('clearTenantUserMappings', () => {
+    // Chainable query-builder stub. UPDATE/DELETE end in .execute(); the revoke SELECT
+    // ends in .getRawMany(). Each call to createQueryBuilder gets its own stub so we can
+    // assert per-statement without cross-talk.
+    const makeQb = (overrides: { affected?: number; rawMany?: unknown[] } = {}) => {
+      const qb: Record<string, jest.Mock> = {};
+      const chain = () => qb;
+      qb.select = jest.fn(chain);
+      qb.update = jest.fn(chain);
+      qb.set = jest.fn(chain);
+      qb.delete = jest.fn(chain);
+      qb.where = jest.fn(chain);
+      qb.andWhere = jest.fn(chain);
+      qb.execute = jest.fn().mockResolvedValue({ affected: overrides.affected ?? 0 });
+      qb.getRawMany = jest.fn().mockResolvedValue(overrides.rawMany ?? []);
+      return qb;
+    };
+
+    it('returns zeros and skips queries when the tenant does not exist', async () => {
+      tenantRepository.findOne.mockResolvedValueOnce(null);
+
+      const result = await service.clearTenantUserMappings(mockTenantId);
+
+      expect(result).toEqual({
+        delegatedRowsUnmapped: 0,
+        appOnlyRowsDeleted: 0,
+        tokensRevoked: 0,
+        tokenRevocationFailures: 0,
+      });
+      expect(tenantUserRepository.createQueryBuilder).not.toHaveBeenCalled();
+    });
+
+    it('matches the tenant regardless of isActive (works after deactivation)', async () => {
+      tenantRepository.findOne.mockResolvedValueOnce(mockTenant as MicrosoftTenant);
+      tenantUserRepository.createQueryBuilder
+        .mockReturnValueOnce(makeQb({ affected: 0 }) as never)
+        .mockReturnValueOnce(makeQb({ affected: 0 }) as never);
+
+      await service.clearTenantUserMappings(mockTenantId);
+
+      expect(tenantRepository.findOne).toHaveBeenCalledWith({ where: { tenantId: mockTenantId } });
+    });
+
+    it('default: unmaps delegated rows and deletes pure app-only rows via bulk queries', async () => {
+      tenantRepository.findOne.mockResolvedValueOnce(mockTenant as MicrosoftTenant);
+      const updateQb = makeQb({ affected: 2 });
+      const deleteQb = makeQb({ affected: 3 });
+      tenantUserRepository.createQueryBuilder
+        .mockReturnValueOnce(updateQb as never)
+        .mockReturnValueOnce(deleteQb as never);
+
+      const result = await service.clearTenantUserMappings(mockTenantId);
+
+      expect(result.delegatedRowsUnmapped).toBe(2);
+      expect(result.appOnlyRowsDeleted).toBe(3);
+      expect(result.tokensRevoked).toBe(0);
+      // UPDATE preserves delegated rows (refresh_token IS NOT NULL); DELETE removes app-only.
+      expect(updateQb.update).toHaveBeenCalled();
+      expect(updateQb.andWhere).toHaveBeenCalledWith('refresh_token IS NOT NULL');
+      expect(deleteQb.delete).toHaveBeenCalled();
+      expect(deleteQb.andWhere).toHaveBeenCalledWith('refresh_token IS NULL');
+      // No token revocation on the default path.
+      expect(mockedAxios.post).not.toHaveBeenCalled();
+    });
+
+    it('revoke path: revokes each delegated token then deletes all tenant rows', async () => {
+      tenantRepository.findOne.mockResolvedValueOnce(mockTenant as MicrosoftTenant);
+      const selectQb = makeQb({
+        rawMany: [{ refreshToken: 'rt-1' }, { refreshToken: 'rt-2' }, { refreshToken: null }],
+      });
+      const deleteQb = makeQb({ affected: 5 });
+      tenantUserRepository.createQueryBuilder
+        .mockReturnValueOnce(selectQb as never)
+        .mockReturnValueOnce(deleteQb as never);
+      mockedAxios.post.mockResolvedValue({ data: {} } as never);
+
+      const result = await service.clearTenantUserMappings(mockTenantId, {
+        revokeDelegatedTokens: true,
+      });
+
+      // Null refresh token is filtered out — only two revocation calls.
+      expect(mockedAxios.post).toHaveBeenCalledTimes(2);
+      expect(result.tokensRevoked).toBe(2);
+      expect(result.tokenRevocationFailures).toBe(0);
+      expect(result.appOnlyRowsDeleted).toBe(5);
+      expect(result.delegatedRowsUnmapped).toBe(0);
+      expect(deleteQb.delete).toHaveBeenCalled();
+    });
+
+    it('revoke path: counts revocation failures without aborting the teardown', async () => {
+      tenantRepository.findOne.mockResolvedValueOnce(mockTenant as MicrosoftTenant);
+      const selectQb = makeQb({ rawMany: [{ refreshToken: 'rt-1' }, { refreshToken: 'rt-2' }] });
+      const deleteQb = makeQb({ affected: 2 });
+      tenantUserRepository.createQueryBuilder
+        .mockReturnValueOnce(selectQb as never)
+        .mockReturnValueOnce(deleteQb as never);
+      mockedAxios.post
+        .mockResolvedValueOnce({ data: {} } as never)
+        .mockRejectedValueOnce(new Error('revoke failed') as never);
+
+      const result = await service.clearTenantUserMappings(mockTenantId, {
+        revokeDelegatedTokens: true,
+      });
+
+      expect(result.tokensRevoked).toBe(1);
+      expect(result.tokenRevocationFailures).toBe(1);
+      // Teardown still deletes rows despite the failed revocation.
+      expect(result.appOnlyRowsDeleted).toBe(2);
     });
   });
 });

--- a/src/services/tenant/tenant-user.service.ts
+++ b/src/services/tenant/tenant-user.service.ts
@@ -427,6 +427,8 @@ export class TenantUserService {
       const chunk = externalUserIds.slice(i, i + CHUNK);
       const rows = await this.tenantUserRepository.find({
         where: { externalUserId: In(chunk) },
+        // Load the tenant so callers can tell app-only users apart and read tenant status.
+        relations: ['tenant'],
       });
       found.push(...rows);
     }

--- a/src/services/tenant/tenant-user.service.ts
+++ b/src/services/tenant/tenant-user.service.ts
@@ -7,6 +7,7 @@ import { MicrosoftUser } from '../../entities/microsoft-user.entity';
 import { AppOnlyAuthService } from '../auth/app-only-auth.service';
 import { TtlCache } from '../../utils/ttl-cache.util';
 import { executeGraphApiCall } from '../../utils/outlook-api-executor.util';
+import { mapWithConcurrency } from '../../utils/concurrent-map.util';
 import { MICROSOFT_CONFIG } from '../../constants';
 import { MicrosoftOutlookConfig } from '../../interfaces/config/outlook-config.interface';
 
@@ -35,6 +36,20 @@ export interface TenantUserLookupResult {
 }
 
 /**
+ * Summary of a tenant user-mapping teardown (see {@link TenantUserService.clearTenantUserMappings}).
+ */
+export interface ClearTenantMappingsResult {
+  /** Rows that also had delegated OAuth tokens and were unmapped (app-only columns nulled, row kept). */
+  delegatedRowsUnmapped: number;
+  /** Pure app-only rows that were deleted. */
+  appOnlyRowsDeleted: number;
+  /** Delegated refresh tokens successfully revoked at Microsoft (only when `revokeDelegatedTokens` is set). */
+  tokensRevoked: number;
+  /** Delegated refresh-token revocations that failed (best-effort; teardown continues regardless). */
+  tokenRevocationFailures: number;
+}
+
+/**
  * Service for looking up and mapping Microsoft 365 users within a tenant.
  *
  * This service provides tenant-wide user lookup capabilities using app-only
@@ -59,6 +74,13 @@ export class TenantUserService {
    * TTL: 1 hour (user IDs don't change, but we want to handle deletions)
    */
   private readonly userIdCache = new TtlCache<string, TenantUserLookupResult>(60 * 60 * 1000);
+
+  /**
+   * Concurrency ceiling for per-user refresh-token revocation during teardown.
+   * Kept small so a tenant with many mapped users doesn't burst Microsoft's
+   * token endpoint (each revocation is an independent HTTP call).
+   */
+  private readonly REVOCATION_CONCURRENCY = 5;
 
   constructor(
     @InjectRepository(MicrosoftTenant)
@@ -532,6 +554,152 @@ export class TenantUserService {
       const errorMessage = error instanceof Error ? error.message : 'Unknown error';
       this.logger.error(`[listUsers] Failed to list users: ${errorMessage}`);
       throw new Error(`Failed to list users: ${errorMessage}`);
+    }
+  }
+
+  /**
+   * Remove a tenant's app-only footprint from the shared `microsoft_users` table.
+   *
+   * Used by the tenant-disconnect flow. It runs at most two bulk SQL statements
+   * (no per-row database loop, no recursion):
+   *
+   * - **Dual-capability rows** (a row that also carries delegated OAuth tokens): the
+   *   app-only columns (`tenant_id`, `microsoft_user_id`, `user_principal_name`) are
+   *   nulled in a single `UPDATE`, preserving the user's still-valid delegated login.
+   * - **Pure app-only rows** (no delegated tokens): deleted in a single `DELETE`.
+   *
+   * When `revokeDelegatedTokens` is set, the teardown is aggressive: every delegated
+   * refresh token for the tenant is first revoked at Microsoft (bounded concurrency to
+   * respect rate limits), then **all** of the tenant's rows are deleted. Revocation is
+   * best-effort — a failed revocation is counted but never aborts the teardown.
+   *
+   * @param tenantId - Microsoft tenant ID (Azure AD tenant GUID). Matched regardless of
+   *   the tenant's `isActive` flag, so it works after the connection has been deactivated.
+   * @param options.revokeDelegatedTokens - Also revoke and delete delegated rows (default: false).
+   * @returns Counts of what was unmapped, deleted, and revoked.
+   */
+  async clearTenantUserMappings(
+    tenantId: string,
+    options?: { revokeDelegatedTokens?: boolean },
+  ): Promise<ClearTenantMappingsResult> {
+    const revokeDelegatedTokens = options?.revokeDelegatedTokens ?? false;
+    const result: ClearTenantMappingsResult = {
+      delegatedRowsUnmapped: 0,
+      appOnlyRowsDeleted: 0,
+      tokensRevoked: 0,
+      tokenRevocationFailures: 0,
+    };
+
+    // Resolve the internal PK (the FK stored on microsoft_users.tenant_id). Match by GUID
+    // only — disconnect deactivates the tenant first, so an isActive filter would miss it.
+    const tenant = await this.tenantRepository.findOne({ where: { tenantId } });
+    if (!tenant) {
+      this.logger.warn(`[clearTenantUserMappings] Tenant not found: ${tenantId} — nothing to clear`);
+      return result;
+    }
+
+    this.logger.log(
+      `[clearTenantUserMappings] Clearing user mappings for tenant ${tenantId} ` +
+      `(revokeDelegatedTokens=${revokeDelegatedTokens})`,
+    );
+
+    if (revokeDelegatedTokens) {
+      // Aggressive purge: revoke every delegated refresh token, then delete all rows.
+      // Bulk-select only the tokens we need (no entity hydration, no N+1).
+      const rows = await this.tenantUserRepository
+        .createQueryBuilder('u')
+        .select('u.refresh_token', 'refreshToken')
+        .where('u.tenant_id = :id', { id: tenant.id })
+        .andWhere('u.refresh_token IS NOT NULL')
+        .getRawMany<{ refreshToken: string | null }>();
+
+      const refreshTokens = rows
+        .map((row) => row.refreshToken)
+        .filter((token): token is string => Boolean(token));
+
+      if (refreshTokens.length > 0) {
+        const revocations = await mapWithConcurrency(
+          refreshTokens,
+          this.REVOCATION_CONCURRENCY,
+          (token) => this.revokeRefreshToken(token),
+        );
+        for (const ok of revocations) {
+          if (ok) {
+            result.tokensRevoked++;
+          } else {
+            result.tokenRevocationFailures++;
+          }
+        }
+      }
+
+      const deleteResult = await this.tenantUserRepository
+        .createQueryBuilder()
+        .delete()
+        .where('tenant_id = :id', { id: tenant.id })
+        .execute();
+      result.appOnlyRowsDeleted = deleteResult.affected ?? 0;
+    } else {
+      // Safe default: keep delegated logins, drop only the app-only footprint.
+      const now = new Date();
+
+      const unmapResult = await this.tenantUserRepository
+        .createQueryBuilder()
+        .update()
+        .set({
+          tenant: null,
+          microsoftUserId: null,
+          userPrincipalName: null,
+          updatedAt: now,
+        })
+        .where('tenant_id = :id', { id: tenant.id })
+        .andWhere('refresh_token IS NOT NULL')
+        .execute();
+      result.delegatedRowsUnmapped = unmapResult.affected ?? 0;
+
+      const deleteResult = await this.tenantUserRepository
+        .createQueryBuilder()
+        .delete()
+        .where('tenant_id = :id', { id: tenant.id })
+        .andWhere('refresh_token IS NULL')
+        .execute();
+      result.appOnlyRowsDeleted = deleteResult.affected ?? 0;
+    }
+
+    // Cached lookups for this tenant now point at gone/changed rows — drop them.
+    this.userIdCache.clear();
+
+    this.logger.log(
+      `[clearTenantUserMappings] Done for tenant ${tenantId}: ` +
+      `${result.delegatedRowsUnmapped} unmapped, ${result.appOnlyRowsDeleted} deleted, ` +
+      `${result.tokensRevoked} tokens revoked, ${result.tokenRevocationFailures} revocation failures`,
+    );
+
+    return result;
+  }
+
+  /**
+   * Revoke a single delegated refresh token at Microsoft. Best-effort: resolves `true`
+   * on success and `false` on failure (logged, never thrown) so a bad token can't abort
+   * a bulk teardown.
+   */
+  private async revokeRefreshToken(refreshToken: string): Promise<boolean> {
+    try {
+      await axios.post(
+        'https://login.microsoftonline.com/common/oauth2/v2.0/logout',
+        new URLSearchParams({
+          token: refreshToken,
+          token_type_hint: 'refresh_token',
+        }),
+        { headers: { 'Content-Type': 'application/x-www-form-urlencoded' } },
+      );
+      return true;
+    } catch (error) {
+      this.logger.warn(
+        `[revokeRefreshToken] Failed to revoke a delegated token: ${
+          error instanceof Error ? error.message : 'Unknown error'
+        }`,
+      );
+      return false;
     }
   }
 

--- a/src/services/tenant/tenant-user.service.ts
+++ b/src/services/tenant/tenant-user.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, Logger, Inject } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
+import { Repository, In } from 'typeorm';
 import axios from 'axios';
 import { MicrosoftTenant } from '../../entities/microsoft-tenant.entity';
 import { MicrosoftUser } from '../../entities/microsoft-user.entity';
@@ -405,6 +405,32 @@ export class TenantUserService {
     );
 
     return tenantUser;
+  }
+
+  /**
+   * Bulk-load the persisted `MicrosoftUser` rows for a set of external user ids, in one (or a
+   * few chunked) query. Used by bulk provisioning to detect which users already exist / are
+   * already connected without issuing a query per user. The `IN (...)` list is chunked so a
+   * very large batch can't exceed the database's parameter/packet limits.
+   *
+   * @param externalUserIds - Host user ids to look up.
+   * @returns The existing rows; an external id with no row is simply absent from the result.
+   */
+  async findUsersByExternalIds(externalUserIds: string[]): Promise<MicrosoftUser[]> {
+    if (externalUserIds.length === 0) {
+      return [];
+    }
+
+    const CHUNK = 500;
+    const found: MicrosoftUser[] = [];
+    for (let i = 0; i < externalUserIds.length; i += CHUNK) {
+      const chunk = externalUserIds.slice(i, i + CHUNK);
+      const rows = await this.tenantUserRepository.find({
+        where: { externalUserId: In(chunk) },
+      });
+      found.push(...rows);
+    }
+    return found;
   }
 
   /**

--- a/src/utils/concurrent-map.util.spec.ts
+++ b/src/utils/concurrent-map.util.spec.ts
@@ -1,0 +1,55 @@
+import { mapWithConcurrency } from './concurrent-map.util';
+
+describe('mapWithConcurrency', () => {
+  it('returns an empty array for empty input without invoking the worker', async () => {
+    const worker = jest.fn();
+    const result = await mapWithConcurrency([], 4, worker);
+    expect(result).toEqual([]);
+    expect(worker).not.toHaveBeenCalled();
+  });
+
+  it('maps every item and preserves input order', async () => {
+    const items = [1, 2, 3, 4, 5];
+    const result = await mapWithConcurrency(items, 2, async (n) => n * 10);
+    expect(result).toEqual([10, 20, 30, 40, 50]);
+  });
+
+  it('passes the index to the worker', async () => {
+    const result = await mapWithConcurrency(['a', 'b', 'c'], 3, async (item, index) => `${index}:${item}`);
+    expect(result).toEqual(['0:a', '1:b', '2:c']);
+  });
+
+  it('never exceeds the concurrency ceiling', async () => {
+    let inFlight = 0;
+    let maxInFlight = 0;
+    const items = Array.from({ length: 12 }, (_, i) => i);
+
+    await mapWithConcurrency(items, 3, async (n) => {
+      inFlight++;
+      maxInFlight = Math.max(maxInFlight, inFlight);
+      // Yield so overlapping workers are observable.
+      await new Promise((resolve) => setTimeout(resolve, 1));
+      inFlight--;
+      return n;
+    });
+
+    expect(maxInFlight).toBeLessThanOrEqual(3);
+    expect(maxInFlight).toBeGreaterThan(1);
+  });
+
+  it('clamps concurrency to at least 1', async () => {
+    const result = await mapWithConcurrency([1, 2, 3], 0, async (n) => n);
+    expect(result).toEqual([1, 2, 3]);
+  });
+
+  it('rejects if a worker rejects', async () => {
+    await expect(
+      mapWithConcurrency([1, 2, 3], 2, async (n) => {
+        if (n === 2) {
+          throw new Error('boom');
+        }
+        return n;
+      }),
+    ).rejects.toThrow('boom');
+  });
+});

--- a/src/utils/concurrent-map.util.ts
+++ b/src/utils/concurrent-map.util.ts
@@ -1,0 +1,49 @@
+/**
+ * Map over `items` running at most `concurrency` `worker` calls at a time.
+ *
+ * A fixed pool of worker loops each pull the next index from a shared cursor until
+ * the list is exhausted — bounded concurrency without recursion and without
+ * allocating one promise per item up front. Use it to speed up I/O-bound fan-out
+ * (e.g. per-user Microsoft Graph calls) while keeping a ceiling that respects Graph
+ * rate limits.
+ *
+ * Results preserve input order. A rejecting `worker` rejects the whole call, so wrap
+ * per-item work in try/catch when partial failures should be tolerated.
+ *
+ * @param items - Items to process.
+ * @param concurrency - Maximum number of concurrent `worker` calls (clamped to >= 1).
+ * @param worker - Async function invoked with each item and its index.
+ * @returns Results in the same order as `items`.
+ */
+export async function mapWithConcurrency<T, R>(
+  items: readonly T[],
+  concurrency: number,
+  worker: (item: T, index: number) => Promise<R>,
+): Promise<R[]> {
+  const results: R[] = new Array<R>(items.length);
+  if (items.length === 0) {
+    return results;
+  }
+
+  // No point spinning up more runners than there is work.
+  const poolSize = Math.max(1, Math.min(Math.floor(concurrency), items.length));
+  let cursor = 0;
+
+  const runner = async (): Promise<void> => {
+    // Each runner keeps claiming the next unprocessed index until none remain.
+    // `cursor++` is safe here because JS runs this synchronously between awaits.
+    let index = cursor++;
+    while (index < items.length) {
+      results[index] = await worker(items[index], index);
+      index = cursor++;
+    }
+  };
+
+  const runners: Promise<void>[] = [];
+  for (let i = 0; i < poolSize; i++) {
+    runners.push(runner());
+  }
+  await Promise.all(runners);
+
+  return results;
+}


### PR DESCRIPTION
## Overview

This PR bundles a cohesive set of **tenant / app-only user-lifecycle** capabilities for the
Outlook module: safe subscription creation, a scalable full-teardown disconnect, bulk user
onboarding, and an on-demand health/recovery service. Each piece composes the module's existing
primitives (auth-mode-aware create, `$batch`, the status model, lifecycle recovery) rather than
duplicating them.

All features are **app-only aware** (the recent gap) while remaining correct for delegated users,
and the heavy operations run in the **background** with **bounded concurrency** so they scale to
thousands of users without blowing request timeouts or crashing the DB.

## What's included

### 1. Prevent duplicate calendar subscriptions (`4aae6b4`)
A user could hold both a delegated (`/me/events`) and an app-only (`/users/{id}/events`) calendar
subscription for the same mailbox → duplicate webhook notifications. Both create paths now remove
any existing calendar subscription (Microsoft + local) **before** creating the new one — deleted
with the token matching the old sub's own auth mode, best-effort, never blocking creation.

### 2. Full-teardown tenant disconnect, at scale (`ba23b1f`, `6fd68ad`)
`DELETE /auth/microsoft/tenant/connection` gains opt-in teardown:
- `?purge=true` — also delete the tenant's Outlook subscriptions and clear its user mappings.
- `?revokeUserTokens=true` — also revoke + remove delegated tokens.

Delegated logins are preserved (app-only columns nulled) while pure app-only rows are deleted, all
via **bulk SQL**. A purge runs in the **background** (`202`), deletes subscriptions via Graph
`$batch` (≤20/call), and deactivates local rows in a **single `UPDATE`** — roughly `O(N/20)` Graph
round-trips instead of one-per-user. The tenant is deactivated last so the token stays valid during
teardown; the connection flipping to disconnected is the completion signal.

### 3. Bulk-connect users into a tenant (`0a52def`, `a6c905b`)
`POST /auth/microsoft/tenant/users/connect` onboards a list of `{ externalUserId, email }`: upserts
each mapping and creates an app-only subscription (reusing #1 to remove any stale delegated sub).
Runs in the **background** (`202`) at **bounded concurrency** (subscription creation can't be
`$batch`ed — Graph validates each `notificationUrl` at creation). **Already-connected users are
skipped** (two bulk queries) so re-runs never tear down a working connection; delegated-only users
are still processed and converge to app-only.

### 4. Health service — diagnose + recover (`6ee8386`)
`HealthService` returns a per-user verdict (`UserHealthStatus`) combining the `microsoft_users` row
and its active subscription (and, with `verifyAtGraph`, a live Graph check), for one user or a bulk
list, across delegated and app-only. It **auto-fixes the fixable** (missing / expired / stale /
gone-at-Graph — recreated via the user's auth mode) and **reports the rest** (`NEEDS_REAUTH`,
`NEEDS_ADMIN`, `INACTIVE`, …) without looping. This closes a real gap: previously all recovery
recreated via the delegated path, so app-only users could not self-heal.

## New public surface

- **Endpoints:** `POST tenant/users/connect`, `POST tenant/connection?purge`,
  `GET/POST health/*` (`health/:externalUserId`, `health/check`, `health/recover`).
- **Services:** `TenantProvisioningService`, `HealthService`; new `TenantUserService`
  (`clearTenantUserMappings`, `findUsersByExternalIds`) and `MicrosoftSubscriptionService`
  (`verifySubscriptionAtGraph`, batched app-only delete) methods.
- **Events:** `outlook.tenant.users.bulk_connect.completed|failed`,
  `outlook.user.health.recovery.completed|failed`.
- **Types/enums:** `UserHealthStatus`, `BulkConnectUsersDto`, `HealthCheckDto`, result interfaces.
- Small shared util `mapWithConcurrency` (dependency-free bounded concurrency, no recursion).

## Scale & safety

- No expensive per-row loops: bulk `IN` / set-based `UPDATE`/`DELETE`; Graph `$batch` for deletes;
  bounded concurrency (5) for per-user create/verify/revoke.
- Long operations run detached (`202`) and are idempotent (safe to re-run).
- Existing 6h/3am health crons and lifecycle handlers are **unchanged** — the new work runs
  alongside them.

## Testing

- `npm run build` ✔ · `npm run lint` ✔
- Full suite: **317 passing**. The only 2 failures are pre-existing on `main`
  (`AppOnlyAuthService` certificate-message assertions) and untouched by this PR.
- New/updated unit tests: dedupe guard, batched bulk-delete (incl. 20-chunking), `clearTenantUserMappings`,
  bulk-connect (skip/partial-failure/pre-flight), and `HealthService` (verdict per state + recovery
  routing + report-not-recover). Docs pass `dep validate` (the 6 failing docs are pre-existing).

### Chaos + scale suite (`*.chaos.spec.ts` + `src/mock/chaos/`)

A seeded chaos harness wires the **real** service stack to an in-memory Microsoft Graph + DB
behind a disruption layer (latency, 429/503/500/network drops, deterministic per-key fail-plans,
including *fail-after-mutate* to model lost ACKs on non-idempotent creates). All backoff funnels
through fake timers, so retry storms costing **minutes of virtual wall-clock run in milliseconds
of CPU**, with per-scenario consumption reports (attempts per route, injected errors, retry
depths, peak in-flight concurrency, real vs virtual time, heap delta).

**27 scenarios** cover every host-facing flow at scale: 520-user bulk connect (incl. the >500
`IN`-chunk boundary), 600-subscription purge (`$batch` chunk counts, teardown ordering,
revocation concurrency), and 400-user mixed-state health check/recover (exact verdict histogram,
auth-mode recovery routing, convergence on rerun). Assertions are conservation laws, exact
consumption counts, no-duplicate/orphan invariants, and 202-before-completion host contracts —
verified **flake-free across 8 fixed seeds** (`CHAOS_SEED` env; adversarially reviewed by a
multi-agent verification pass).

The harness also surfaced and fixed a real race: `connectUsers` now de-duplicates its input
(duplicate `externalUserId`s previously ran concurrently past the dedupe guard and could
double-subscribe a mailbox). Two known warts are *documented* by explicit tests rather than
hidden: a lost create-ACK leaves an untracked duplicate Graph subscription until expiry, and a
failed subscription save leaves a clientState-guarded Graph orphan.

## Notes / follow-ups

- Background work uses the in-process detached-promise pattern (idempotent, but not durable across a
  process restart). A durable queue is a sensible future step if crash-durability is required.
- Follow-up: route the existing recovery crons through `HealthService` so recovery lives in one
  place (they currently recreate via the delegated path only).

