### PR TITLE
ci: add manual workflow_dispatch trigger to npm publish

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -13,6 +13,10 @@ on:
         description: 'Publish the current package.json version even if the latest tag was not created by release-please'
         type: boolean
         default: false
+      npm-tag:
+        description: 'npm dist-tag to publish under. Use a non-latest tag (e.g. v9-lts) for hotfixes on older releases so the "latest" tag is not moved backward.'
+        type: string
+        default: 'latest'
 
 jobs:
   publish-npm:
@@ -100,4 +104,5 @@ jobs:
         if: env.SHOULD_PUBLISH == 'true'
         env:
           NODE_AUTH_TOKEN: ""
-        run: npm publish --access public 
+          NPM_DIST_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.npm-tag || 'latest' }}
+        run: npm publish --access public --tag "$NPM_DIST_TAG" 

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -7,10 +7,16 @@ on:
       - completed
     branches:
       - main
+  workflow_dispatch:
+    inputs:
+      force:
+        description: 'Publish the current package.json version even if the latest tag was not created by release-please'
+        type: boolean
+        default: false
 
 jobs:
   publish-npm:
-    if: ${{ github.event.workflow_run.conclusion == 'success' && contains(github.event.workflow_run.head_branch, 'main') }}
+    if: ${{ github.event_name == 'workflow_dispatch' || (github.event.workflow_run.conclusion == 'success' && contains(github.event.workflow_run.head_branch, 'main')) }}
     runs-on: ubuntu-latest
     permissions:
       id-token: write
@@ -35,6 +41,11 @@ jobs:
       - name: Check if tag was created in the trigger workflow
         id: check-tag-in-workflow
         run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "SHOULD_PUBLISH=true" >> $GITHUB_ENV
+            echo "Manual dispatch: publishing current package.json version"
+            exit 0
+          fi
           TRIGGER_SHA="${{ github.event.workflow_run.head_sha }}"
           TAG_SHA=$(git rev-list -n 1 $LATEST_TAG)
           echo "Trigger SHA: $TRIGGER_SHA, Tag SHA: $TAG_SHA"
@@ -77,8 +88,13 @@ jobs:
           TAG_VERSION=${LATEST_TAG#v}
           echo "Package version: $PACKAGE_VERSION, Tag version: $TAG_VERSION"
           if [ "$PACKAGE_VERSION" != "$TAG_VERSION" ]; then
-            echo "Version mismatch! Package version ($PACKAGE_VERSION) does not match tag version ($TAG_VERSION)"
-            exit 1
+            if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ "${{ inputs.force }}" = "true" ]; then
+              echo "Version mismatch ignored (force dispatch): publishing package version $PACKAGE_VERSION"
+            else
+              echo "Version mismatch! Package version ($PACKAGE_VERSION) does not match tag version ($TAG_VERSION)"
+              echo "Re-run with the 'force' input enabled to publish the current package.json version anyway."
+              exit 1
+            fi
           fi
       - name: Publish to npm
         if: env.SHOULD_PUBLISH == 'true'


### PR DESCRIPTION
## What
Adds a `workflow_dispatch` trigger to `npm-publish.yml` so the package can be published manually from the Actions tab (or `gh workflow run`), in addition to the existing automatic release-please trigger.

## Why
Publishing uses npm **OIDC trusted publishing**, which only works inside CI — there is no CLI equivalent. A manual trigger lets us publish on demand while keeping the no-secret OIDC flow.

## Changes
- Add `workflow_dispatch` with an optional `force` boolean input.
- Update the job `if` so manual runs (which have no `workflow_run` context) are not skipped.
- Short-circuit the tag-check step to `SHOULD_PUBLISH=true` on manual dispatch.
- Keep the version-match guard on manual runs, but allow `force` to bypass a tag/`package.json` mismatch.

## Notes
- `workflow_dispatch` only appears in the UI once this file is on the default branch, hence merging to `main`.
- Run manually after merge:
  ```bash
  gh workflow run npm-publish.yml --ref main            # publish current version
  gh workflow run npm-publish.yml --ref main -f force=true
  ```