### PR TITLE
fix(auth): don't reject delegated users with a null tokenExpiry

### DIFF
--- a/src/services/auth/microsoft-auth.service.spec.ts
+++ b/src/services/auth/microsoft-auth.service.spec.ts
@@ -222,3 +222,71 @@ describe.each(backends)(
     });
   },
 );
+
+/**
+ * Regression coverage for "Outlook - 500 Error on calendar
+ * disconnection". Legacy delegated rows created before the tokenExpiry column
+ * existed still hold valid access/refresh tokens but have tokenExpiry = null.
+ * The old guard rejected them as "app-only user or not yet authenticated",
+ * turning every token fetch (webhook create/delete, reconciliation, sync) into a
+ * failure — surfacing as an HTTP 500 on disconnect. A null expiry must instead be
+ * treated as "unknown → refresh", not "no delegated credentials".
+ */
+interface TokenService {
+  getUserAccessToken(params: {
+    internalUserId?: number;
+    externalUserId?: string;
+    includeInactive?: boolean;
+    cache?: boolean;
+  }): Promise<string>;
+  refreshAccessToken(refreshToken: string, internalUserId: number): Promise<string>;
+  isTokenExpired(tokenExpiry: Date | null | undefined, bufferMinutes?: number): boolean;
+}
+
+describe("MicrosoftAuthService delegated-token guard (null tokenExpiry)", () => {
+  function buildService(user: MicrosoftUser | null): TokenService {
+    const repo = { save: jest.fn(), findOne: jest.fn(async () => user) };
+    return new MicrosoftAuthService(
+      new EventEmitter2(),
+      {} as never, // EmailService
+      {} as never, // MicrosoftSubscriptionService
+      baseConfig as never,
+      {} as never, // csrfTokenRepository
+      repo as never,
+      new InMemoryOutlookLockStore(),
+    ) as unknown as TokenService;
+  }
+
+  it("isTokenExpired treats a null/undefined expiry as expired", () => {
+    const service = buildService(null);
+    expect(service.isTokenExpired(null)).toBe(true);
+    expect(service.isTokenExpired(undefined)).toBe(true);
+    // A comfortably-future expiry is still considered valid.
+    expect(service.isTokenExpired(new Date(Date.now() + 60 * 60 * 1000))).toBe(false);
+  });
+
+  it("refreshes a legacy delegated user with null tokenExpiry instead of rejecting it", async () => {
+    const user = makeUser({
+      accessToken: "legacy-access",
+      refreshToken: "legacy-refresh",
+      tokenExpiry: null,
+      scopes: "offline_access Calendars.ReadWrite",
+    });
+    const service = buildService(user);
+    jest.spyOn(service, "refreshAccessToken").mockResolvedValue("refreshed-access");
+
+    await expect(
+      service.getUserAccessToken({ internalUserId: user.id }),
+    ).resolves.toBe("refreshed-access");
+    expect(service.refreshAccessToken).toHaveBeenCalledWith("legacy-refresh", user.id);
+  });
+
+  it("still rejects a genuine app-only user with no delegated tokens", async () => {
+    const user = makeUser({ accessToken: null, refreshToken: null, tokenExpiry: null });
+    const service = buildService(user);
+
+    await expect(
+      service.getUserAccessToken({ internalUserId: user.id }),
+    ).rejects.toThrow(/has no delegated auth tokens/);
+  });
+});

--- a/src/services/auth/microsoft-auth.service.ts
+++ b/src/services/auth/microsoft-auth.service.ts
@@ -451,7 +451,14 @@ export class MicrosoftAuthService {
 
       // A user that only has app-only (tenant) access has no delegated tokens. Delegated
       // token retrieval is not possible for them until they complete the OAuth flow.
-      if (user.accessToken == null || user.refreshToken == null || user.tokenExpiry == null) {
+      //
+      // Only accessToken + refreshToken define "has delegated credentials". A missing
+      // tokenExpiry is NOT an app-only signal: legacy delegated rows (created before the
+      // tokenExpiry column existed, and never re-authenticated since) still hold valid
+      // access/refresh tokens with a null expiry. Treat those as "expiry unknown" and let
+      // processTokenInfo refresh them, which repopulates tokenExpiry — rather than
+      // falsely rejecting the user as app-only / not authenticated.
+      if (user.accessToken == null || user.refreshToken == null) {
         throw new Error(
           `Microsoft user ${String(user.id)} has no delegated auth tokens (app-only user or not yet authenticated)`
         );
@@ -489,7 +496,7 @@ export class MicrosoftAuthService {
     tokenInfo: {
       accessToken: string;
       refreshToken: string;
-      tokenExpiry: Date;
+      tokenExpiry: Date | null;
       scopes: string;
     },
     internalUserId: number
@@ -1076,7 +1083,10 @@ export class MicrosoftAuthService {
    * @param bufferMinutes - Buffer time in minutes before actual expiry to consider token expired
    * @returns Boolean indicating if token is expired
    */
-  isTokenExpired(tokenExpiry: Date, bufferMinutes = 5): boolean {
+  isTokenExpired(tokenExpiry: Date | null | undefined, bufferMinutes = 5): boolean {
+    // Unknown expiry (e.g. legacy delegated rows predating the tokenExpiry column) is
+    // treated as expired so the caller refreshes and repopulates it.
+    if (tokenExpiry == null) return true;
     // Add buffer time to current time to prevent using tokens that will expire very soon
     const currentTimeWithBuffer = new Date(Date.now() + bufferMinutes * 60 * 1000);
     return tokenExpiry < currentTimeWithBuffer;


### PR DESCRIPTION
## Summary

`getUserAccessToken()` gated on `accessToken && refreshToken && tokenExpiry` all being non-null. Legacy delegated `microsoft_users` rows — created before the `tokenExpiry` column existed and never re-authenticated since — still hold valid `accessToken`/`refreshToken` but have `tokenExpiry = null`. The guard misclassified them as *"has no delegated auth tokens (app-only user or not yet authenticated)"*, so **every** delegated-token fetch for them failed.

## Problem

```
Calendar disconnection failed at webhook_deletion: Failed to delete webhook subscription:
Failed to get valid access token: Microsoft user 875 has no delegated auth tokens
(app-only user or not yet authenticated)
```

On disconnect, `deleteSubscription()` needs a delegated token to delete the Microsoft webhook; the throw re-propagates uncaught through the calendar controller → **HTTP 500**.

The same guard also breaks reconciliation and event sync for these users. In production this is not a niche case: **973 of 980 active delegated users** have `token_expiry = NULL` (the column was added without a backfill). New Relic shows ~9.6k failures over 30 days across webhook / reconciliation / sync flows, all from this one guard.

## Root Cause

`tokenExpiry == null` was treated as "no delegated credentials". But delegated credentials are defined by `accessToken` + `refreshToken` alone — a missing expiry just means the expiry is unknown, not that the user is app-only. Affected users could not self-heal, because the guard threw *before* the refresh path (which would have repopulated `tokenExpiry`).

## Solution

- Guard checks only `accessToken`/`refreshToken`. Genuine app-only / unauthenticated users (no tokens) are still rejected with the same error.
- `isTokenExpired(null | undefined)` returns `true` → a null expiry is treated as expired.
- `processTokenInfo` accepts a nullable `tokenExpiry`, so it refreshes (repopulating `tokenExpiry`) instead of rejecting.

## Tests

`npm test` — 15/15 pass, including 3 new regression cases:
- `isTokenExpired` treats null/undefined expiry as expired (future date still valid).
- A legacy delegated user with null `tokenExpiry` is refreshed, not rejected.
- A genuine app-only user (no access/refresh token) is still rejected.

`npm run build` and `eslint --max-warnings 0` both clean.

## Reviewer Guide

- `src/services/auth/microsoft-auth.service.ts` — the guard, `isTokenExpired`, and `processTokenInfo` signature.
- `src/services/auth/microsoft-auth.service.spec.ts` — new `delegated-token guard (null tokenExpiry)` describe block.

## Rollout

This unblocks users going forward (their tokens refresh on next access and repopulate `tokenExpiry`). A companion backfill migration in the ScheduleAI backend sets `token_expiry` for the ~973 existing rows so they recover immediately rather than lazily. A version bump / publish is needed for the backend to consume this.
