### PR TITLE
fix(calendar): preserve tenant_id when persisting Microsoft user updates

### DIFF
--- a/src/services/auth/microsoft-auth.service.spec.ts
+++ b/src/services/auth/microsoft-auth.service.spec.ts
@@ -86,6 +86,10 @@ describe.each(backends)(
           savedUser = Object.assign(savedUser, u);
           return savedUser;
         }),
+        update: jest.fn(async (_criteria: unknown, patch: Partial<MicrosoftUser>) => {
+          savedUser = Object.assign(savedUser, patch);
+          return { affected: 1 } as never;
+        }),
         findOne: jest.fn(async () => savedUser),
       };
 
@@ -170,6 +174,7 @@ describe.each(backends)(
       const ttlEmit = jest.spyOn(eventEmitter, "emit");
       const repo = {
         save: jest.fn(async (u: MicrosoftUser) => u),
+        update: jest.fn(async () => ({ affected: 1 }) as never),
         findOne: jest.fn(async () => user),
       };
       const ttlService = new MicrosoftAuthService(
@@ -199,6 +204,9 @@ describe.each(backends)(
       const failEmit = jest.spyOn(failingEmitter, "emit");
       const failingRepo = {
         save: jest.fn(async () => {
+          throw new Error("db down");
+        }),
+        update: jest.fn(async () => {
           throw new Error("db down");
         }),
         findOne: jest.fn(async () => user),

--- a/src/services/auth/microsoft-auth.service.ts
+++ b/src/services/auth/microsoft-auth.service.ts
@@ -333,7 +333,10 @@ export class MicrosoftAuthService {
   ): Promise<void> {
     // Find existing user (including inactive ones) or create a new one
     let user = await this.microsoftUserRepository.findOne({
-      where: { externalUserId: externalUserId }
+      where: { externalUserId: externalUserId },
+      // Load the tenant relation so the save() below preserves tenant_id for
+      // app-only users when re-authenticating (delegated flow).
+      relations: ['tenant'],
     });
 
     if (!user) {
@@ -924,7 +927,17 @@ export class MicrosoftAuthService {
         internalUser.refreshToken = newRefreshToken;
         internalUser.tokenExpiry = new Date(Date.now() + response.data.expires_in * 1000);
 
-        await this.microsoftUserRepository.save(internalUser);
+        // Targeted update. save(internalUser) would rewrite the whole row, and
+        // since this query does not load the `tenant` relation it would null out
+        // tenant_id for app-only users.
+        await this.microsoftUserRepository.update(
+          { id: internalUserId },
+          {
+            accessToken: newAccessToken,
+            refreshToken: newRefreshToken,
+            tokenExpiry: internalUser.tokenExpiry,
+          },
+        );
         this.invalidateUserCache(internalUser);
 
         // Return just the access token
@@ -984,7 +997,13 @@ export class MicrosoftAuthService {
   ): Promise<void> {
     try {
       user.status = MicrosoftUserStatus.CORRUPTED;
-      await this.microsoftUserRepository.save(user);
+      // Targeted update. save(user) would rewrite the whole row, and if the
+      // `tenant` relation is not loaded on this instance it would null out
+      // tenant_id for app-only users.
+      await this.microsoftUserRepository.update(
+        { id: user.id },
+        { status: MicrosoftUserStatus.CORRUPTED },
+      );
       this.invalidateUserCache(user);
       this.logger.warn(`User ${String(user.id)} marked CORRUPTED (reason: ${reason})`);
     } catch (dbErr) {

--- a/src/services/calendar/calendar.service.ts
+++ b/src/services/calendar/calendar.service.ts
@@ -178,8 +178,13 @@ export class CalendarService {
       const calendarId = response.data.id;
 
       // Persist so subsequent processes / restarts don't need to re-fetch.
-      user.defaultCalendarId = calendarId;
-      await this.microsoftUserRepository.save(user);
+      // Persist via a targeted column update. save(user) would rewrite the whole
+      // row, and since this query does not load the `tenant` relation it would null
+      // out tenant_id for app-only users, breaking tenant token resolution.
+      await this.microsoftUserRepository.update(
+        { externalUserId },
+        { defaultCalendarId: calendarId },
+      );
       this.defaultCalendarIdCache.set(externalUserId, calendarId);
 
       this.logger.log(`Cached calendar ID for user ${externalUserId}`);


### PR DESCRIPTION
## Summary

A full-entity `repository.save()` on `microsoft_users` silently nulled the
`tenant_id` foreign key whenever the row was loaded without its `tenant`
relation. For app-only users that severed the tenant link, which cascades into
token resolution and kills calendar sync.

## The mechanism

```
 load row (relation NOT selected)          mutate one field            save(entity)
┌──────────────────────────────┐        ┌───────────────────┐      ┌──────────────────────┐
│ tenant_id = T                │        │ defaultCalendarId │      │ writes EVERY column  │
│ tenant (relation) = <unset>  │  ──►   │   = "..."         │  ──► │ tenant  = unset       │
└──────────────────────────────┘        └───────────────────┘      │ ⇒ tenant_id = NULL ✗ │
                                                                    └──────────────────────┘
```

`save(entity)` persists the whole object graph. A relation that was never
loaded is `null` in memory, so TypeORM writes the FK back as `NULL` — even
though the caller only meant to touch one unrelated column.

## Why it breaks sync

```
tenant_id = NULL
   │
   ▼
app-only token resolution has no tenant to resolve
   │
   ▼
falls back to the delegated-token path
   │
   ▼
no per-user tokens exist  →  every reconcile / sync aborts
```

The row still looks "connected" (subscription present), so the failure is
silent until real-time sync stops flowing.

## Fix — write only what you mean to write

Replace full-entity saves with targeted column updates; where a full save is
genuinely required, load the relation first so it round-trips intact.

| Write site | Intent | Before | After |
|---|---|---|---|
| `getDefaultCalendarId` | set default calendar | `save(user)` | `update({…}, { defaultCalendarId })` |
| `refreshAccessToken` | refresh tokens | `save(user)` | `update({…}, { …tokens })` |
| `markUserAsCorrupted` | flip status | `save(user)` | `update({…}, { status })` |
| `saveMicrosoftUser` | full upsert | `save(user)` | `save(user)` + load `tenant` relation |

```
        BEFORE                                AFTER
 ┌───────────────────┐               ┌───────────────────────────┐
 │ read whole row    │               │ (skip read where possible)│
 │ set one field     │      ──►      │ UPDATE … SET one_field    │
 │ write whole row ✗ │               │ FK untouched ✓            │
 └───────────────────┘               └───────────────────────────┘
```

## Invariant

> A single-field update must never rewrite unrelated columns. Persisting a
> partial change uses a scoped `update(...)`, not a full-entity `save(...)`,
> unless every relation is loaded.

## Tests

- Build, lint, and the auth + calendar unit suites pass.
- Auth-service repository mocks extended to cover the new `update` path.
